### PR TITLE
tigの checkout コマンドを restore / switch コマンドに置き換える

### DIFF
--- a/.tigrc
+++ b/.tigrc
@@ -102,8 +102,8 @@ bind diff    K      ?git cherry-pick %(commit)
 bind main    =      ?git restore %(commit)
 bind refs    =      ?git switch %(branch)
 
-# - で直前のブランチに戻る (checkout -)
-bind generic -      ?git checkout -
+# - で直前のブランチに戻る (switch -)
+bind generic -      ?git switch -
 
 # T で tag
 bind main    T ?git tag "%(prompt Enter tag name: )" %(commit)

--- a/.tigrc
+++ b/.tigrc
@@ -109,10 +109,9 @@ bind generic -      ?git switch -
 bind main    T ?git tag "%(prompt Enter tag name: )" %(commit)
 bind refs    T ?git tag "%(prompt Enter tag name: )" %(branch)
 
-# B でブランチを作成してそのブランチに移動 (checkout -b)
-bind main    B      ?git checkout -b "%(prompt Enter branch name: )" %(branch)
-bind refs    B      ?git checkout -b "%(prompt Enter branch name: )" %(branch)
-bind main    <Esc>b ?git checkout -b "%(prompt Enter branch name: )" %(commit)
+# B でブランチを作成してそのブランチに移動 (switch -c)
+bind main    B      ?git switch -c "%(prompt Enter branch name: )"
+bind refs    B      ?git switch -c "%(prompt Enter branch name: )" %(branch)
 
 # M で merge
 bind main    M      ?git merge %(branch)

--- a/.tigrc
+++ b/.tigrc
@@ -98,10 +98,9 @@ bind diff    K      ?git cherry-pick %(commit)
 
 ## 以下、Shift付きでブランチ指定、Alt付きでコミットID指定のコマンド
 
-# = で checkout
-bind main    =      ?git checkout %(branch)
-bind refs    =      ?git checkout %(branch)
-bind main    <Esc>= ?git checkout %(commit)
+# = で restore / switch
+bind main    =      ?git restore %(commit)
+bind refs    =      ?git switch %(branch)
 
 # - で直前のブランチに戻る (checkout -)
 bind generic -      ?git checkout -


### PR DESCRIPTION
tigで checkout コマンドを割り当てているキーバインドを restore / switch コマンドへの割り当てに置き換えた。