### PR TITLE
chore(ghostty): sync window/skin settings from live config

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,6 +1,9 @@
 # Window
-fullscreen = true
 macos-non-native-fullscreen = false
+window-decoration = auto
+window-height = 45
+window-width = 160
+window-padding-x = 8
 
 # Skin
 theme = Material Design Colors
@@ -8,7 +11,6 @@ background-opacity = 0.85
 background-blur = macos-glass-regular
 font-family = "UDEV Gothic NF"
 font-size = 16
-window-padding-x = 8
 
 # Keybinds
 ## Cmd+T で tmux のプレフィックス Ctrl+A に続けて Ctrl+T を送る


### PR DESCRIPTION
## 概要

手で編集したライブの `~/.config/ghostty/config` の更新を、追跡対象の `.config/ghostty/config` に取り込む。dotfiles は `$HOME` のミラーなので、リポジトリを正とする状態に戻す。

## 変更内容

- `fullscreen = true` を削除
- `window-decoration = auto` / `window-height = 45` / `window-width = 160` を追加
- `window-padding-x = 8` を Skin → Window セクションへ移動

ウィンドウをフルスクリーンから固定サイズ（160x45）・装飾あり・パディング付きに変更したもの。Keybinds セクションは変更なし。

## 検証

- `diff ~/.config/ghostty/config .config/ghostty/config` が差分なし（完全一致）であることを確認済み。
