### PR TITLE
feat(ghostty,fish): add Cmd window keybinds and isolated tmux sessions

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -46,8 +46,19 @@ end
 
 # 起動時に tmux を自動で立ち上げる（tmux 内・VSCode 内では除く）
 if type -q tmux; and test -z "$TMUX"; and test "$TERM_PROGRAM" != vscode
-    # 既存セッション "main" があればアタッチ、なければ新規作成
-    exec tmux new-session -A -s main
+    # main が既に他のウィンドウで使用中（クライアント接続済み）なら独立した新規セッション、
+    # そうでなければ "main" にアタッチ（無ければ作成）
+    if tmux has-session -t main 2>/dev/null; and test (tmux list-clients -t main 2>/dev/null | count) -gt 0
+        # 独立セッション。ウィンドウを閉じて detach したら自動破棄し、溜めない。
+        # 注: destroy-unattached は未アタッチのセッションに設定した瞬間に破棄されるため、
+        # client-attached フックでアタッチ後に有効化する（main には影響させない）。
+        set -l sname win-$fish_pid
+        tmux new-session -d -s $sname
+        tmux set-hook -t $sname client-attached "set-option -t $sname destroy-unattached on"
+        exec tmux attach -t $sname
+    else
+        exec tmux new-session -A -s main
+    end
 end
 end
 

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -13,13 +13,27 @@ font-family = "UDEV Gothic NF"
 font-size = 16
 
 # Keybinds
-## Cmd+T で tmux のプレフィックス Ctrl+A に続けて Ctrl+T を送る
+# tmux への橋渡し。Cmd 系 = ペイン操作 / Cmd+Shift 系 = ウィンドウ操作。
+# いずれもプレフィックス Ctrl+a (\x01) に続けてキーを送る。
+
+## ── ペイン操作 ──
+# Cmd+T        : 横分割（prefix + Ctrl+T）
 keybind = cmd+t=text:\x01\x14
-# Cmd+Shift+T で tmux のプレフィックス Ctrl+A に続けて Ctrl+Shift+T を送る
-# Ctrl+Shift+T は CSI u 形式 (ESC[116;6u) で送信（要 extended-keys）
+# Cmd+Shift+T  : 縦分割（prefix + Ctrl+Shift+T を CSI u 形式 ESC[116;6u で送信。要 extended-keys）
 keybind = cmd+shift+t=text:\x01\x1b[116;6u
-# Cmd+] / cmd+[ で tmux のプレフィックス(Ctrl+a)+ n/p を送りペインを番号順に次/前へ移動する
+# Cmd+] / Cmd+[: ペインを番号順に次/前へ移動（prefix + n/p）
 keybind = cmd+]=text:\x01n
 keybind = cmd+[=text:\x01p
-# Cmd+W で tmux のプレフィックス(Ctrl+a)+ x を送りカレントペーンを閉じる（確認プロンプト y/n あり）
+# Cmd+W        : カレントペインを閉じる（prefix + x。確認プロンプト y/n あり）
 keybind = cmd+w=text:\x01x
+
+## ── ウィンドウ操作 ──
+# Cmd+N              : 新規ウィンドウ作成（prefix + c）
+keybind = cmd+n=text:\x01c
+# Cmd+Shift+[ / ]    : ウィンドウを前/次へ切替（S-Left / S-Right を送信。tmux 側 bind -n に対応）
+keybind = cmd+shift+[=text:\x1b[1;2D
+keybind = cmd+shift+]=text:\x1b[1;2C
+
+## ── ghostty ネイティブ操作 ──
+# Cmd+Shift+N  : ghostty の新規ウィンドウ（Cmd+N は tmux ウィンドウ作成に割当済みのため代替）
+keybind = cmd+shift+n=new_window

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -40,15 +40,17 @@ set -g visual-activity off
 bind r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded"
 
 # ペイン分割を直感的に（横分割=Ctrl+T / 縦分割=Ctrl+Shift+T）。新ペインは現在のパスを引き継ぐ
+# ghostty の Cmd+T / Cmd+Shift+T が呼ぶ
 bind C-t split-window -h -c "#{pane_current_path}"
 bind C-S-t split-window -v -c "#{pane_current_path}"
 unbind '"'
 unbind %
 
-# 新規ウィンドウも現在のパスで
+# 新規ウィンドウも現在のパスで（ghostty の Cmd+N が呼ぶ）
 bind c new-window -c "#{pane_current_path}"
 
-# ペイン番号順に移動（n=次 / p=前、末尾↔先頭で循環）
+# ペイン番号順に移動（n=次 / p=前、末尾↔先頭で循環）。ghostty の Cmd+] / Cmd+[ から呼ばれる
+# 注: デフォルトの next/previous-window を上書きしている。ウィンドウ切替は下記 S-Left/S-Right に分離
 bind n select-pane -t :.+
 bind p select-pane -t :.-
 
@@ -64,7 +66,7 @@ bind -n M-Right select-pane -R
 bind -n M-Up    select-pane -U
 bind -n M-Down  select-pane -D
 
-# Shift+矢印 でプレフィックス無しのウィンドウ切替
+# Shift+矢印 でプレフィックス無しのウィンドウ切替（ghostty の Cmd+Shift+[ / Cmd+Shift+] からも呼ばれる）
 bind -n S-Left  previous-window
 bind -n S-Right next-window
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 ## 構成
 
 - **fish** (`.config/fish/`)
-  - `config.fish`: starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動）、git-wt 統合（`git wt --init fish`。`if type -q git-wt` ガード付きで未インストール時は no-op）、起動時の tmux 自動アタッチ（`main` セッション。tmux 内・VSCode 内は除外）、nodenv 初期化。
+  - `config.fish`: starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動）、git-wt 統合（`git wt --init fish`。`if type -q git-wt` ガード付きで未インストール時は no-op）、起動時の tmux セッション方針（tmux 内・VSCode 内は除外。`main` が他ウィンドウで使用中＝クライアント接続済みなら独立セッション `win-<pid>` を作り、`client-attached` フックで `destroy-unattached on` を貼って閉じたら自動破棄。未使用時は `main` に attach＝無ければ作成）、nodenv 初期化。
   - `conf.d/`: fzf 関連のキーバインド（`fzf_cd_keybind`=Ctrl-O, `fzf_tab_complete`=Tab, `ghq_fzf_keybind`=Ctrl-G）。`config.fish` の `fzf --fish` で定義される widget に bind しているため、読み込み順序に依存する。
   - `functions/`: `ghq_fzf`（ghq リポジトリを fzf 選択して cd）、`ll`/`ls`（eza ラッパ）。
   - プラグインマネージャは使っていない（旧 fisherman 構成は廃止）。
 - **tmux** (`.tmux.conf`): tmux 3.6+ 前提。prefix は Ctrl-a。ghostty 連携のため CSI u 拡張キーや truecolor を明示設定。
-- **ghostty** (`.config/ghostty/config`): フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。Cmd 系キーを tmux のプレフィックスシーケンスに変換するキーバインドを持つ（`.tmux.conf` のバインドと対で機能する）。
+- **ghostty** (`.config/ghostty/config`): フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。Cmd 系キーを tmux のプレフィックスシーケンスに変換するキーバインドを持つ（`.tmux.conf` のバインドと対で機能する）。Cmd 系＝ペイン操作（分割・移動・閉じる）、Cmd+Shift 系＝ウィンドウ操作（新規 `Cmd+N`／前後切替）、`Cmd+Shift+N` のみ ghostty ネイティブの新規ウィンドウ。
 - **starship** (`.config/starship.toml`): 2 行構成プロンプト。Nerd Font グリフ前提。
 - **tig** (`.tigrc`): git 操作を tig 上で完結させる大量のカスタムキーバインド。差分表示に **delta**、GitHub 連携（`;` `w`）に **gh** を使う。
 - **gh** (`.config/gh/config.yml`): 設定のみ。認証情報 (`hosts.yml`) は `.gitignore` で除外。


### PR DESCRIPTION
## 概要

ライブ設定で実機検証済みの tmux × ghostty 連携キーバインド拡張をリポジトリに取り込む。`Cmd` 系をペイン操作、`Cmd+Shift` 系をウィンドウ操作に割り当て、機能本体は tmux 側に持たせて ghostty はプレフィックス `Ctrl+a` + キーを送るだけにする設計。

## 変更内容

- **feat(ghostty)**: keybind を追加 — `cmd+n`（新規ウィンドウ）/ `cmd+shift+[` `cmd+shift+]`（ウィンドウ前後切替）/ `cmd+shift+n`（ghostty ネイティブ新規ウィンドウ）。コメントをペイン/ウィンドウ/ネイティブの3分類に再編。
- **feat(fish)**: 起動時 tmux セッション方針を変更。`main` が他ウィンドウで使用中（クライアント接続済み）なら独立セッション `win-<pid>` を作成し、`client-attached` フックで `destroy-unattached` を有効化して閉じたら自動破棄。未使用時は従来どおり `main` に attach。
- **docs**: `.tmux.conf` の各 bind に呼び出し元の ghostty キーを注記（機能変更なし）。`CLAUDE.md` の fish / ghostty の説明を実態に合わせて更新。

## 設計メモ

- ウィンドウ切替の正規ルートは `S-Left` / `S-Right`（prefix 不要）。`bind n` / `bind p` はデフォルトの next/previous-window を上書きして select-pane に再割り当て済みのため、ghostty も S-Left/S-Right を送る。
- `destroy-unattached` は未アタッチのセッションに設定した瞬間に破棄される罠があるため、`client-attached` フックでアタッチ後に有効化し、`-t $sname` で独立セッションに限定（`main` や `-g` には設定しない）。

## 検証

リポジトリ内ファイルの構文チェック（実機挙動はライブ設定で確認済み）:

- fish: `fish --no-execute .config/fish/config.fish` → OK
- ghostty: `ghostty +validate-config --config-file=.config/ghostty/config` → exit 0
- tmux: 独立ソケットで `start-server` → exit 0
