### PR TITLE
feat(claude): extract TS/JS and commit conventions into skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,10 +34,7 @@
 
 ## TypeScript / JavaScript
 
-- 公開オブジェクト型は `interface`、ユニオン/ユーティリティ型は `type` を使う。
-- `const` を優先する。`any` は禁止し、`unknown` + 型の絞り込みで対応する。
-- フォーマッタは **Prettier**、Linter は **ESLint** に従う。
-- import 順序は 標準 → 外部 → 内部 とし、相対パスは最小限にする。
+- TypeScript / JavaScript の規約は `typescript-conventions` skill に従う。
 
 ## ツールの優先方針
 
@@ -49,9 +46,4 @@
 
 ## コミット規約
 
-- **Conventional Commits** 形式に従う: `<type>(<scope>): <subject>`
-- 主な type: `feat`（新機能）, `fix`（バグ修正）, `docs`, `style`, `refactor`, `test`, `chore`, `perf`
-- subject は**英語**・命令形・小文字始まり・末尾ピリオドなし。件名は 50〜72 文字以内を目安にする。
-- 破壊的変更は `feat!:` のように `!` を付けるか、フッターに `BREAKING CHANGE:` を書く。
-- **絵文字は使わない**。
-- 作業が一区切りしたら commit を**提案する**が、実行はユーザーの確認後に行う（勝手に commit しない）。
+- コミット規約は `commit` skill に従う。

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: commit
+description: "git commit を作成・提案する時に使う。Conventional Commits 形式（type(scope): subject）、subject の規約（英語・命令形・小文字始まり・末尾ピリオドなし・50〜72 文字目安）、絵文字禁止、破壊的変更の feat! / BREAKING CHANGE 表記を適用する。コミットメッセージを書く場面で発動する。"
+user-invocable: true
+allowed-tools: "Bash(git:*)"
+---
+
+# コミット規約
+
+git commit を作成・提案するときに従う規約。これがコミットメッセージ規約の単一の source of truth。
+
+## 優先順位
+
+- リポジトリ固有のコミットルール（`CONTRIBUTING.md`, `.gitmessage` 等）があれば**それを優先**する。
+- なければ以下の **Conventional Commits** に従う。
+
+## 形式
+
+`<type>(<scope>): <subject>`
+
+主な type:
+
+- `feat`: 新機能
+- `fix`: バグ修正
+- `docs`: ドキュメント
+- `style`: 整形（挙動を変えない）
+- `refactor`: リファクタリング
+- `test`: テスト
+- `chore`: 雑務
+- `perf`: パフォーマンス改善
+
+## subject の規約
+
+- **英語**・**命令形**・**小文字始まり**・**末尾ピリオドなし**。
+- 件名は **50〜72 文字以内**を目安にする。
+
+## 破壊的変更
+
+- `feat!:` のように `!` を付けるか、フッターに `BREAKING CHANGE:` を書く。
+
+## 禁止事項
+
+- **絵文字は使わない**。
+- **AI co-author credits は含めない**。
+
+## 実行フロー（Fail-Safe）
+
+- 作業が一区切りしたら commit を**提案**する。実行はユーザーの確認後に行い、勝手に commit しない。
+
+```bash
+git add <paths>
+git commit -m "<type>(<scope>): <subject>"
+```

--- a/.claude/skills/pr-lifecycle/SKILL.md
+++ b/.claude/skills/pr-lifecycle/SKILL.md
@@ -37,11 +37,7 @@ git checkout -b <branch-name>
 
 #### 3. コミット
 
-- リポジトリ固有のコミットルール（CONTRIBUTING.md, .gitmessage等）を優先する
-- ルールがなければConventional Commits形式を使用する
-  - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `style`, `perf`
-  - Format: `type(scope): description`
-- AI co-author credits は含めない
+- コミットメッセージは `/commit` skill の規約に従う（Conventional Commits 形式・subject 規約・絵文字禁止・AI co-author credits 不含・リポジトリ固有ルール優先）。
 
 ```bash
 git add .

--- a/.claude/skills/typescript-conventions/SKILL.md
+++ b/.claude/skills/typescript-conventions/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: typescript-conventions
+description: "TypeScript / JavaScript のコードを書く・レビューする・リファクタする時に使う。型定義（公開オブジェクト型は interface、ユニオン/ユーティリティ型は type）、const 優先・any 禁止（unknown + 絞り込み）、Prettier/ESLint 準拠、import 順序（標準→外部→内部・相対パス最小化）を適用する。.ts/.tsx/.js/.jsx ファイルの編集時に発動する。"
+user-invocable: true
+---
+
+# TypeScript / JavaScript 規約
+
+TypeScript / JavaScript のコードを書く・直す・レビューするときに従う規約。整形・lint はツールに任せ、手動整形しない。
+
+## 型定義
+
+- **公開オブジェクト型は `interface`** を使う。
+- **ユニオン型・ユーティリティ型は `type`** を使う。
+
+```ts
+// 公開する構造体は interface
+interface User {
+  id: string;
+  name: string;
+}
+
+// ユニオン / ユーティリティは type
+type Status = "active" | "archived";
+type PartialUser = Partial<User>;
+```
+
+## 変数・型の安全性
+
+- **`const` を優先**する。再代入が必要なときだけ `let`。
+- **`any` は禁止**。外部入力など型が不明な値は `unknown` で受け、型の絞り込み（type guard / `typeof` / スキーマ検証）で確定させてから使う。
+
+```ts
+function parse(input: unknown): User {
+  if (typeof input === "object" && input !== null && "id" in input) {
+    // ここで User として扱えるよう絞り込む
+  }
+  throw new Error("invalid input");
+}
+```
+
+## フォーマッタ / Linter
+
+- フォーマッタは **Prettier**、Linter は **ESLint** に従う。保存時整形を前提にし、手動整形しない。
+
+## import 順序
+
+- **標準 → 外部 → 内部** の順に並べる。
+- 相対パスは最小限にする。
+
+既存コードのスタイル・命名・イディオムを優先し、勝手に新流儀を持ち込まない。


### PR DESCRIPTION
## 概要

常時ロードされる global CLAUDE.md から、特定状況でのみ関連するルールをオンデマンドの skill に切り出し、無関係なセッションでの context コストを減らす。

## 仕分けの方針

- **常時ロードのまま残す**: 言語 / 応答スタイル / 作業の進め方 / コーディング全般 / ツールの優先方針。毎ターン適用される短い行動ルールで、skill 化すると発動前に必要になり機能しない、またはトリガーが広すぎる。
- **skill 化する**:
  - **TypeScript / JavaScript 規約** — 言語固有で状況依存。非 TS セッションでは純粋な context 浪費。
  - **コミット規約** — コミット時のみ関連。既存 `pr-lifecycle` skill に簡易版が重複していた。

## 変更点

- `typescript-conventions` skill 新設（型定義 / const・any / Prettier・ESLint / import 順序）。`.ts/.tsx/.js/.jsx` 編集時に発動。
- `commit` skill 新設。コミット規約の単一 source of truth（Conventional Commits・subject 規約・絵文字禁止・BREAKING CHANGE）。
- `pr-lifecycle` の commit 節を `/commit` skill 参照に置換し、規約の重複・ドリフトを解消。
- `CLAUDE.md` の TS/JS・コミット規約節を 1 行ポインタへ圧縮。他節は無変更。

## 補足

- 新規 skill ディレクトリは `.gitignore` の whitelist `!.claude/skills/` により追跡対象。
