### PR TITLE
feat(claude): enable context-mode plugin via marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,5 +32,16 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "context-mode": {
+      "source": {
+        "source": "github",
+        "repo": "mksglu/context-mode"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "context-mode@context-mode": true
   }
 }


### PR DESCRIPTION
## 概要

`context-mode` プラグインを追加し、Claude Code の設定に反映する。

## 変更内容

`.claude/settings.json` に以下を追加:

- `extraKnownMarketplaces.context-mode`: GitHub リポジトリ `mksglu/context-mode` を marketplace として登録
- `enabledPlugins`: `context-mode@context-mode` を有効化

## 補足

`context-mode` は大きな出力（ログ・テスト結果・JSON など）を context window を圧迫せずに処理するためのツール群を提供する。
