### PR TITLE
refactor(claude): reduce pr-lifecycle skill token footprint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"/Users/haribote/.claude/hooks/context-mode-cache-heal.mjs\""
+          }
+        ]
+      }
     ]
   },
   "extraKnownMarketplaces": {

--- a/.claude/skills/address-pr-review/SKILL.md
+++ b/.claude/skills/address-pr-review/SKILL.md
@@ -38,6 +38,8 @@ gh pr view <NUMBER> --json reviewRequests,reviews,reviewDecision,state,headRefNa
 - `reviewDecision`: `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED`
 - `state`: `OPEN` / `CLOSED` / `MERGED`
 
+状態判定（`reviewDecision` / `state` / `reviewRequests`）に必要なフィールドだけを参照する。`reviews` のレビュー本文は大きい場合があるため、本文全体の精読は避ける（未解決コメントは手順2で取得する）。
+
 未提出レビュアーの扱い:
 - **Copilot**: 常に待機する。Copilotのレビューが届くまで次のステップに進まない。
 - **それ以外**: ユーザーに **待機するか続行するか** 確認する。勝手に判断しない。
@@ -54,6 +56,11 @@ gh pr view <NUMBER> --json reviewRequests,reviews,reviewDecision,state,headRefNa
 
 出力: 未解決スレッド(`isResolved == false`)のみのJSON配列。各要素は `threadId`, `outdated`, `path`, `line`, `firstComment`, `replies` を含む。`outdated: true` のスレッドも含まれるが、コード変更済みのため対応不要の可能性が高い。内容は確認すること。
 
+コンテキスト予算:
+
+- **context-mode あり**: スクリプトを `ctx_execute`(language: "shell") 経由で実行し、コンパクトな index（`threadId` / `path` / `line` / `outdated` / firstComment の author と先頭1行 / reply 数）だけを出力させる。各スレッドの本文は手順4で対象になったとき `ctx_search` で引く。全文 JSON をコンテキストに入れない。
+- **無し**: スクリプトを直接実行する（出力は既に未解決のみ・コメント上限10件に絞られている）。
+
 ### 3. PRブランチをチェックアウト
 
 ```bash
@@ -64,7 +71,7 @@ gh pr checkout <NUMBER>
 
 未解決スレッドごとに以下を実行:
 
-1. **該当コードを読む**: `path` と `line` から対象ファイル・行を確認
+1. **該当コードを読む**: `path` と `line` を使い、Read の offset/limit で当該行の周辺（目安 ±30 行）だけ読む。ファイル全体を読まない。広い文脈が要るときだけ範囲を広げる
 2. **指摘を評価**: 以下の基準で判断
 
 **修正する:**

--- a/.claude/skills/pr-lifecycle/SKILL.md
+++ b/.claude/skills/pr-lifecycle/SKILL.md
@@ -11,6 +11,13 @@ PRのライフサイクルをゲート付きで管理する。各ステップに
 
 `$ARGUMENTS` でフェーズを指定できる: `create`, `review`, `merge`。省略時は現在のPR状態を判定して適切なフェーズから開始する。
 
+## コンテキスト予算
+
+生コマンド出力をそのままコンテキストに流さない。
+
+- diff・JSON・チェック結果は、まず `--stat` 等の要約形を見る。全文が要るときだけ対象を絞って取得する。
+- 大きい出力（full diff、レビュースレッド JSON）は context-mode（`ctx_execute` / `ctx_batch_execute`）で digest 化し、要約だけ受け取る。context-mode が無ければ対象を絞った取得で代替する。
+
 ## Phase 1: Create（PR作成）
 
 ### ゲート条件
@@ -22,10 +29,15 @@ PRのライフサイクルをゲート付きで管理する。各ステップに
 #### 1. 状況把握
 
 ```bash
-git status
+git status --short
 git rev-parse --abbrev-ref HEAD
-git diff HEAD
+git diff --stat HEAD
 ```
+
+`--stat` で変更の形（ファイル・増減行）を把握する。commit message / PR body を書くのに意味的内容が要る場合:
+
+- **context-mode あり**: `git diff HEAD` を `ctx_execute`(language: "shell") に流し、digest（per-file の hunk header `@@`、追加/削除された関数・見出し行、代表 hunk）だけを `console.log` で受け取る。生 diff はサンドボックスに留まる。
+- **無し**: 変更ファイルごとに `git diff HEAD -- <path>` を必要な分だけ読む。全ファイルを一括 `git diff HEAD` しない。
 
 #### 2. ブランチ作成（必要な場合）
 


### PR DESCRIPTION
## 概要

`pr-lifecycle` skill（`/pr`）のトークン消費を削減する。原因は SKILL.md 本文ではなく、手順が指示する生コマンド出力がそのまま会話コンテキストに流れ込む点にあった。

## 変更内容

### `pr-lifecycle/SKILL.md`
- 冒頭に「コンテキスト予算」節を追加（要約形を優先し、大きい出力は context-mode で digest 化する原則）。
- Phase 1「状況把握」を `git status --short` / `git diff --stat HEAD` に変更。意味的内容が要る場合の二層フォールバック（context-mode あり=digest／無し=対象を絞った `git diff HEAD -- <path>`）を明記。

### `address-pr-review/SKILL.md`
- 「未解決コメント取得」に digest 経由（context-mode あり=index のみ／無し=直実行）を追記。
- 「該当コードを読む」を Read の offset/limit による窓読み（±30 行）に変更。
- 「PR状態確認」に、状態判定フィールドのみ参照し `reviews` 本文の精読は避ける注記を追加。

### `settings.json`
- context-mode のキャッシュ修復スクリプトを `SessionStart` フックとして追加。

## 設計メモ
- skill はグローバル使用のため、context-mode 不在環境でも対象を絞った取得だけで成立するよう degrade gracefully にしている。
- `allowed-tools` は一次ソース（公式 docs）で「制限ではなく事前承認の allowlist」と確認済みのため、context-mode ツール利用に frontmatter 変更は不要。

## 検証
- `git diff --stat HEAD`（233 B）は full diff（5105 B）の約 1/22。Phase 1 の無条件全 diff 投入が要約に置き換わることを確認。
- context-mode 経由の digest 化・E2E（`/pr create` 実走 + `/ctx-stats`）は実 PR フロー時に確認予定。
