### PR TITLE
docs(claude): default to biome over prettier/eslint in ts conventions

### DIFF
--- a/.claude/skills/typescript-conventions/SKILL.md
+++ b/.claude/skills/typescript-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript-conventions
-description: "TypeScript / JavaScript のコードを書く・レビューする・リファクタする時に使う。型定義（公開オブジェクト型は interface、ユニオン/ユーティリティ型は type）、const 優先・any 禁止（unknown + 絞り込み）、Prettier/ESLint 準拠、import 順序（標準→外部→内部・相対パス最小化）を適用する。.ts/.tsx/.js/.jsx ファイルの編集時に発動する。"
+description: "TypeScript / JavaScript のコードを書く・レビューする・リファクタする時に使う。型定義（公開オブジェクト型は interface、ユニオン/ユーティリティ型は type）、const 優先・any 禁止（unknown + 絞り込み）、Biome 準拠（デフォルト、フォールバックは Prettier/ESLint）、import 順序（標準→外部→内部・相対パス最小化）を適用する。.ts/.tsx/.js/.jsx ファイルの編集時に発動する。"
 user-invocable: true
 ---
 
@@ -41,7 +41,11 @@ function parse(input: unknown): User {
 
 ## フォーマッタ / Linter
 
-- フォーマッタは **Prettier**、Linter は **ESLint** に従う。保存時整形を前提にし、手動整形しない。
+- **デフォルトは Biome**。formatter と linter を単一ツール・単一設定（`biome.json`）で兼ねる。新規プロジェクトではまず Biome を選ぶ。
+- **フォールバックは Prettier（フォーマッタ）+ ESLint（Linter）**。次の場合に切り替える。
+  - 既存プロジェクトが Prettier/ESLint を採用している（「既存コードに合わせる」原則を優先）。
+  - フレームワーク固有の ESLint プラグインや、Biome が未対応・カバー不足の Lint ルール（高度な type-aware ルール等）が必要。
+- いずれの場合も保存時整形を前提にし、手動整形しない。
 
 ## import 順序
 


### PR DESCRIPTION
## 概要

`typescript-conventions` skill のフォーマッタ/Linter 方針を、固定の Prettier+ESLint から **デフォルト Biome・フォールバック Prettier+ESLint** の 2 層構成に変更する。

## 背景

2026 年時点のトレンドを一次ソースで確認した結果:

- **Biome**: v2（2025-06）で type-aware linting・プラグイン・複数ファイル解析を追加。2026 年時点で v2.3、423+ ルール。単一バイナリ・単一設定（`biome.json`）・ESLint+Prettier 比 10〜25倍高速。新規プロジェクトでの採用が急増し、トレンドを捉えている側。
- **Prettier + ESLint**: ESLint v9 (flat config) が依然デファクト（週 5000万 DL）。プラグイン生態系が最強で、成熟・大規模・フレームワーク依存の強いコードベースでは依然最有力。確立された安定側。

トレンドを捉えている Biome をデフォルトに、確立された安定側の Prettier+ESLint をフォールバックに位置づける。フォールバックの判断基準は既存原則「既存コードに合わせる」と整合する。

## 変更内容

- frontmatter `description`: `Prettier/ESLint 準拠` → `Biome 準拠（デフォルト、フォールバックは Prettier/ESLint）`（発動トリガー維持のため両ツール名を残す）
- 本文「フォーマッタ / Linter」セクション: デフォルト=Biome、フォールバック=Prettier+ESLint（既存採用時／Biome 非対応要件時）の 2 層構成に書き換え

ドキュメント（skill 規約）のみの変更。dotfiles リポジトリには JS/TS ビルドがないため実コードへの影響なし。
