### PR TITLE
fix(fish): prepend homebrew to PATH on startup

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,3 +1,9 @@
+# Homebrew を PATH 先頭へ（/usr/bin の Apple git より優先させる）
+# --path: PATH を直接操作。永続しないので config.fish 側で毎起動設定する
+if test -x /opt/homebrew/bin/brew
+    fish_add_path --path --move --prepend /opt/homebrew/bin /opt/homebrew/sbin
+end
+
 if status is-interactive
 # Commands to run in interactive sessions can go here
 


### PR DESCRIPTION
## 変更内容

- `config.fish` の冒頭に `fish_add_path` ブロックを追加し、起動のたびに `/opt/homebrew/bin` と `/opt/homebrew/sbin` を PATH 先頭に追加するようにした
- これにより、Homebrew でインストールしたツール（`git` 等）が `/usr/bin` の macOS システムバイナリより優先される
- `test -x /opt/homebrew/bin/brew` でガードしているため、Homebrew 未インストール環境では no-op

## 背景

このブロックは手元の `~/.config/fish/config.fish` には存在していたが、リポジトリにコミットされていなかった。このままでは新規マシンでブートストラップした際に fish が Apple 提供のシステムバイナリを使ってしまう。
