### PR TITLE
chore(claude): track only declared skills and agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,20 @@
 # gh の認証トークンを含むため追跡しない（config.yml のみ管理）
 .config/gh/hosts.yml
 
-# Claude Code 設定は CLAUDE.md・settings.json・agents・skills だけを追跡する。
+# Claude Code 設定は CLAUDE.md・settings.json と、宣言済みの agents・skills だけを追跡する。
 # 会話ログ・キャッシュ・セッション等のマシン固有/機密データ（projects, history,
 # sessions, file-history, backups, plans, cache, plugins, settings.local.json 等）は除外する。
+# skills/agents はサードパーティ製の混入を防ぐため、各エントリを per-entry で再 include する。
 .claude/*
 !.claude/CLAUDE.md
 !.claude/settings.json
 !.claude/agents/
+.claude/agents/*
+!.claude/agents/tdd-expert.md
 !.claude/skills/
+.claude/skills/*
+!.claude/skills/commit/
+!.claude/skills/five-whys/
+!.claude/skills/pr-lifecycle/
+!.claude/skills/typescript-conventions/
+!.claude/skills/worktree/

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -3,4 +3,4 @@ thumbs.db
 .idea/
 node_modules/
 npm-debug.log
-
+**/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 - **git** (`.gitconfig`, `.gitignore_global`)
 - **zsh** (`.zprofile`, `.zshrc`): fish へ移行する前のログインシェル設定（brew shellenv / PATH のみ）。
 - **Homebrew** (`.Brewfile`): インストール済みの CLI ツール・GUI アプリ・フォントの一覧（`brew bundle --global` の既定パス `~/.Brewfile` のミラー）。`brew bundle dump --describe --no-vscode` で再生成する。VS Code 拡張は意図的に含めない。
-- **Claude Code** (`.claude/`): グローバル個人設定 (`CLAUDE.md`)・エディタ設定 (`settings.json`: permissions allowlist・Stop フック)・サブエージェント (`agents/`: `tdd-expert`)・skills (`skills/`: `five-whys`, `commit`, `pr-lifecycle`, `worktree`, `typescript-conventions`) を追跡する。会話ログ・キャッシュ・セッション・`settings.local.json` 等のマシン固有/機密データは `.gitignore` の whitelist で除外している（`.claude/*` を無視し、上記の許可エントリ＝ `CLAUDE.md` / `settings.json` / `agents/` / `skills/` だけを再 include）。
+- **Claude Code** (`.claude/`): グローバル個人設定 (`CLAUDE.md`)・エディタ設定 (`settings.json`: permissions allowlist・Stop フック)・サブエージェント (`agents/`: `tdd-expert`)・skills (`skills/`: `five-whys`, `commit`, `pr-lifecycle`, `worktree`, `typescript-conventions`) を追跡する。会話ログ・キャッシュ・セッション・`settings.local.json` 等のマシン固有/機密データは `.gitignore` の whitelist で除外している（`.claude/*` を無視し、`CLAUDE.md` / `settings.json` を再 include。`agents/` と `skills/` はディレクトリ全体ではなく、宣言済みの個別エントリ＝ `tdd-expert` と上記5 skill だけを per-entry で再 include する。これによりプラグインや手動インストールで入ったサードパーティ製の skill / agent は自動的に追跡対象外になる）。
 
 ## ブートストラップ（新しい Mac での再現手順）
 


### PR DESCRIPTION
## 概要

`.claude/` 配下にサードパーティ製の skill（Cloudflare 系9個）が手動インストールで出現し、`.gitignore` の whitelist が `!.claude/skills/`（ディレクトリ全体を再 include）だったため未追跡として混入していた。宣言済みの個人用エントリだけを追跡するよう whitelist を厳格化する。あわせて `.gitignore_global` に Claude のローカル設定の除外を追加する。

## 変更内容

- **`.gitignore`**: `.claude/skills` と `.claude/agents` を per-entry 方式に変更。ディレクトリ全体ではなく、宣言済みの5 skill（`commit` / `five-whys` / `pr-lifecycle` / `typescript-conventions` / `worktree`）と `tdd-expert` だけを再 include する。プラグインや手動インストールで入ったサードパーティ製は自動的に追跡対象外になる。
- **`.gitignore_global`**: `**/.claude/settings.local.json` を追加し、Claude Code のローカル設定を全リポジトリで無視する（不要な空行も整理）。
- **`CLAUDE.md`**: whitelist の記述を新しい per-entry 方式に合わせて更新。

## 検証

```
git check-ignore -v .claude/skills/cloudflare/SKILL.md   # → ignore される
git check-ignore -v .claude/skills/commit/SKILL.md       # → 追跡される（出力なし）
git check-ignore -v .claude/agents/tdd-expert.md         # → 追跡される（出力なし）
git ls-files .claude/skills/ .claude/agents/             # → 5 skill + tdd-expert のみ
```

`git status` から Cloudflare 系9 skill の未追跡表示が消えることを確認済み。

> 注: `.gitignore_global` の変更は dotfiles の運用方針どおり `~/.gitignore_global`（`core.excludesfile`）へ手動反映して有効化する。
