### PR TITLE
chore(npm): harden installs with ignore-scripts and release cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
## 概要

npm のサプライチェーン攻撃に備えて、グローバル `~/.npmrc` のミラーとして `.npmrc` を追加する。

## 変更内容

| 設定 | 効果 |
| --- | --- |
| `ignore-scripts=true` | 依存パッケージの lifecycle script（pre/post install 等）の自動実行を無効化する。悪意ある install スクリプトの実行を防ぐ。 |
| `min-release-age=7` | 公開から 7 日未満のバージョンをインストールしない（npm では単位は日）。npm 11.10.0+ で導入された cooldown 機能で、公開直後に検知前へ消費される malicious package の取り込みリスクを下げる。 |

## 検証

- `min-release-age` は npm 11.10.0+ が必要。ローカルの npm は 11.13.0 でサポート済み。
- `ignore-scripts` は従来からある正式な npm config。

## 参考

- https://www.brandonpugh.com/til/node/package-version-cooldown/
- https://gist.github.com/mcollina/b294a6c39ee700d24073c0e5a4e93104
