### PR TITLE
fix(tig): quote diff-highlight command value

### DIFF
--- a/.tigrc
+++ b/.tigrc
@@ -17,7 +17,7 @@ set diff-options = -m --first-parent
 set refresh-mode = auto
 
 # 差分表示に delta を使う (要 delta インストール. --color-only で +/- 行構造を保持)
-set diff-highlight = delta --color-only
+set diff-highlight = "delta --color-only"
 
 # デフォルトの bind generic G !git gc を無効化する
 bind generic G none


### PR DESCRIPTION
## 概要

`.tigrc` の `diff-highlight` 設定で、空白を含むコマンド値がクオートされていなかったのを修正する。

## 詳細

`diff-highlight` は tigrc(5) で `mixed` 型のオプション。`true` 以外を指定すると、その値は「diff をハイライトするプログラムのパス（文字列）」として扱われる。文字列値が空白を含む場合（`delta --color-only` のように引数付き）、`set` 構文上 `'` または `"` のデリミタが必須。

無クオートだと tig の設定パーサが空白で値を分割し、`delta` の後ろの `--color-only` を余分なトークンとして解釈してパースに失敗する。

```diff
-set diff-highlight = delta --color-only
+set diff-highlight = "delta --color-only"
```

## 根拠（一次ソース）

- [tigrc(5) manual](https://jonas.github.io/tig/doc/tigrc.5.html): `diff-highlight` は `mixed` 型。string 値は `'`/`"` をデリミタとして使用可能。
- tig 2.6.1 リリースノートを確認済み。`diff-highlight`・`set` パース・文字列クオート処理に関する変更は含まれず、本修正の根拠（tigrc(5) の安定した仕様）に影響しない。
