### PR TITLE
chore(herdr): track config and ignore runtime state

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,16 @@
             "command": "\"/Users/haribote/.claude/hooks/context-mode-cache-heal.mjs\""
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/Users/haribote/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,12 @@
+onboarding = false
+
+[theme]
+name = "solarized"
+auto_switch = false
+
+[ui.toast]
+delivery = "system"
+
+[ui]
+show_agent_labels_on_pane_borders = false
+agent_panel_sort = "spaces"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 # gh の認証トークンを含むため追跡しない（config.yml のみ管理）
 .config/gh/hosts.yml
 
+# herdr が生成するマシン固有のセッション状態・ログ（config.toml のみ管理）
+.config/herdr/session.json
+.config/herdr/*.log
+
+# ツールが生成する update-check キャッシュ（マシン固有・追跡不要）
+.config/configstore/
+
 # Claude Code 設定は CLAUDE.md・settings.json と、宣言済みの agents・skills だけを追跡する。
 # 会話ログ・キャッシュ・セッション等のマシン固有/機密データ（projects, history,
 # sessions, file-history, backups, plans, cache, plugins, settings.local.json 等）は除外する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
   - プラグインマネージャは使っていない（旧 fisherman 構成は廃止）。
 - **tmux** (`.tmux.conf`): tmux 3.6+ 前提。prefix は Ctrl-a。ghostty 連携のため CSI u 拡張キーや truecolor を明示設定。
 - **ghostty** (`.config/ghostty/config`): フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。Cmd 系キーを tmux のプレフィックスシーケンスに変換するキーバインドを持つ（`.tmux.conf` のバインドと対で機能する）。Cmd 系＝ペイン操作（分割・移動・閉じる）、Cmd+Shift 系＝ウィンドウ操作（新規 `Cmd+N`／前後切替）、`Cmd+Shift+N` のみ ghostty ネイティブの新規ウィンドウ。
+- **herdr** (`.config/herdr/config.toml`): ワークスペース/タブ/ペイン・エージェント管理ツールの設定。テーマ・トースト通知・UI 表示のみ追跡し、セッション状態（`session.json`）とログ（`herdr-server.log`／`herdr-client.log`）は `.gitignore` で除外する。Claude Code の SessionStart フック（`~/.claude/hooks/herdr-agent-state.sh`）と連携してエージェント状態を herdr へ通知する（フック実体は `~/.claude/hooks/` 配下でマシンローカル・追跡外）。
 - **starship** (`.config/starship.toml`): 2 行構成プロンプト。Nerd Font グリフ前提。
 - **tig** (`.tigrc`): git 操作を tig 上で完結させる大量のカスタムキーバインド。差分表示に **delta**、GitHub 連携（`;` `w`）に **gh** を使う。
 - **gh** (`.config/gh/config.yml`): 設定のみ。認証情報 (`hosts.yml`) は `.gitignore` で除外。

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 | **fish** | `.config/fish/` | starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動 / Ctrl-G ghq）、git-wt 統合（`git wt <branch>` で worktree 切替 cd・補完）、起動時の tmux 自動アタッチ（`main` セッション。tmux 内・VSCode 内は除外）、nodenv 初期化。`conf.d/` に fzf 関連キーバインド、`functions/` に `ghq_fzf` と eza ラッパ（`ll`/`ls`）。プラグインマネージャは未使用。 |
 | **tmux** | `.tmux.conf` | tmux 3.6+ 前提。prefix は `Ctrl-a`。ghostty 連携のため CSI u 拡張キーや truecolor を明示設定。 |
 | **ghostty** | `.config/ghostty/config` | フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。Cmd 系キーを tmux のプレフィックスシーケンスに変換するキーバインドを持つ。 |
+| **herdr** | `.config/herdr/config.toml` | ワークスペース/タブ/ペイン・エージェント管理ツールの設定。テーマ・トースト通知・UI 表示のみ追跡。セッション状態（`session.json`）とログ（`*.log`）は `.gitignore` で除外。 |
 | **starship** | `.config/starship.toml` | 2 行構成プロンプト。Nerd Font グリフ前提。 |
 | **tig** | `.tigrc` | git 操作を tig 上で完結させるカスタムキーバインド。差分表示に [delta](https://github.com/dandavison/delta)、GitHub 連携に `gh` を使う。 |
 | **gh** | `.config/gh/config.yml` | 設定のみ。認証情報（`hosts.yml`）は `.gitignore` で除外。 |


### PR DESCRIPTION
## 概要

herdr（ワークスペース/タブ/ペイン・エージェント管理ツール）の設定を dotfiles に取り込む。既存方針（実体の config は追跡・生成物は除外）に沿って構成する。

## 変更内容

- `.config/herdr/config.toml` を追跡（テーマ・トースト通知・UI 表示設定）
- `.gitignore` にマシン固有の生成物を追加
  - `.config/herdr/session.json`（ワークスペース/ペイン状態）
  - `.config/herdr/*.log`（サーバ／クライアントログ）
  - `.config/configstore/`（ツールの update-check キャッシュ）
- `.claude/settings.json` に SessionStart フックを追加し、エージェント状態を herdr へ通知（`herdr-agent-state.sh session`）
  - フック実体 `~/.claude/hooks/herdr-agent-state.sh` は既存の `context-mode-cache-heal.mjs` と同様マシンローカルで追跡対象外。設定側の宣言のみ追跡する。
- `CLAUDE.md` / `README.md` に herdr の項を追記

## 補足

- `settings.json` の `model` / `tui` 等の個人設定変更は別 PR で扱う。
