### PR TITLE
chore(claude): tweak editor settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,10 +45,10 @@
   },
   "enabledPlugins": {
     "context-mode@context-mode": true,
-    "skill-creator@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "context-mode": {
@@ -57,5 +57,7 @@
         "repo": "mksglu/context-mode"
       }
     }
-  }
+  },
+  "tui": "default",
+  "skipWorkflowUsageWarning": true
 }


### PR DESCRIPTION
## 概要

Claude Code の個人エディタ設定を反映する。

## 変更内容

- `enabledPlugins` のキーをアルファベット順に整列（意味的変化なし）
- `"tui": "default"` を追加
- `"skipWorkflowUsageWarning": true` を追加

## 補足

- working tree には `model` ピンの変更もあったが、値がセッション中に `opus[1m]` → `sonnet` と変化する揮発的なものだったため、本 PR には含めていない。全マシン固定のピンが必要になった時点で 1 行追記する。
