### PR TITLE
chore(git): enable ssh commit signing

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,6 +3,7 @@
 [user]
 	name = KIMURA Tetsuro
 	email = haribote.nobody@gmail.com
+	signingkey = ~/.ssh/id_ed25519.pub
 [core]
 	editor = vi
 	excludesfile = ~/.gitignore_global
@@ -36,6 +37,9 @@
 	enabled = true
 [commit]
 	verbose = true
+	gpgsign = true
+[gpg]
+	format = ssh
 [diff]
 	colorMoved = default
 [branch]


### PR DESCRIPTION
## 概要

master の `required_signatures` ルールセットに合わせ、コミットを SSH 鍵で署名する設定を追加する。

## 変更内容

- `.gitconfig` に SSH 署名設定を追加
  - `[user] signingkey = ~/.ssh/id_ed25519.pub`
  - `[gpg] format = ssh`
  - `[commit] gpgsign = true`

## 前提・注意

- 署名が GitHub 上で **Verified** になるには、同じ公開鍵を GitHub アカウントに **Signing Key** タイプで登録する必要がある（Authentication key 登録だけでは不可）。
- tracked な共有 `.gitconfig` に入れているため、各マシンで `~/.ssh/id_ed25519.pub` が存在し ssh-agent 等で使える必要がある。鍵が無いマシンでは `git commit` が署名失敗する点に留意。
- ローカルでの署名検証（`git log --show-signature`）には別途 `gpg.ssh.allowedSignersFile` の設定が必要（本 PR には含めない）。
