### PR TITLE
chore: Brewfile に ripgrep と jq を追加

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -17,8 +17,12 @@ brew "ghq"
 brew "git"
 # Syntax-highlighting pager for git and diff output
 brew "git-delta"
+# Lightweight and flexible command-line JSON processor
+brew "jq"
 # Node.js version manager
 brew "nodenv"
+# Search tool that recursively searches directories for a regex pattern, using threads
+brew "ripgrep"
 # Cross-shell prompt for astronauts
 brew "starship"
 # Text interface for Git repositories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 ## 横断的な約束ごと
 
 - 配色は ghostty テーマ **"Material Design Colors"** に統一されている。fish の `FZF_*` 配色、`.tmux.conf` のステータスライン、`starship.toml` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 3 箇所を揃える。
-- 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `nodenv`, `tmux`, `git-wt`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。
+- 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`, `git-wt`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。
 
 ## 注意点
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 
 ## 依存コマンド
 
-`starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `nodenv`, `tmux`, `git-wt`。
+`starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`, `git-wt`。
 
 いずれも `.Brewfile` に含まれる。未インストールでも該当機能が無効になるだけで、致命的には壊れない作りにしてある。
 


### PR DESCRIPTION
## 概要
- `.Brewfile` に `ripgrep` と `jq` を追加（アルファベット順、説明コメント付き）
- `CLAUDE.md` と `README.md` の依存コマンド一覧に `rg` と `jq` を追記
- Homebrew 経由で両方をインストールし、新規 fish シェルで `rg`/`jq` が `/opt/homebrew/bin/` を指すことを検証

グローバル `CLAUDE.md` のツール方針では検索に `rg` の使用を必須としているが、これまで Claude Code セッション外では利用できず、`.Brewfile` にも含まれていなかったため bootstrap の再現性が欠けていた。`jq` も同様に macOS 同梱の `/usr/bin/jq` に依存していたため、bootstrap の完全性のためあわせて追加する。

Closes #27

## テスト計画
- [x] `brew bundle check --file=.Brewfile` で構文エラーが無いことを確認（既存の無関係な未解決依存 `raycast`、untrusted な `k1low/tap` の git-wt のみ検出）
- [x] `brew install ripgrep jq` を実行
- [x] `fish -c 'command -v rg; rg --version'` → `/opt/homebrew/bin/rg` を指し、正常動作
- [x] `fish -c 'command -v jq; jq --version'` → `/opt/homebrew/bin/jq` を指し、正常動作