### PR TITLE
git-wt を廃止・除去する

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -29,8 +29,6 @@ brew "starship"
 brew "tig"
 # Terminal multiplexer
 brew "tmux"
-# A Git subcommand that makes `git worktree` simple
-brew "k1low/tap/git-wt"
 cask "font-udev-gothic"
 cask "font-udev-gothic-nf"
 # Terminal emulator that uses platform-native UI and GPU acceleration

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,6 @@
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git show:*)",
-      "Bash(git wt:*)",
-      "Bash(git-wt:*)",
       "Bash(ls:*)",
       "Bash(cat:*)",
       "Bash(rg:*)",

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -45,11 +45,6 @@ if type -q fzf
     fzf --fish | source
 end
 
-# git-wt シェル統合（`git wt <branch>` での worktree 切替 cd と補完を有効化）
-if type -q git-wt
-    git wt --init fish | source
-end
-
 # 起動時に tmux を自動で立ち上げる（tmux 内・VSCode 内では除く）
 if type -q tmux; and test -z "$TMUX"; and test "$TERM_PROGRAM" != vscode
     # main が既に他のウィンドウで使用中（クライアント接続済み）なら独立した新規セッション、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 ## 構成
 
 - **fish** (`.config/fish/`)
-  - `config.fish`: starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動）、git-wt 統合（`git wt --init fish`。`if type -q git-wt` ガード付きで未インストール時は no-op）、起動時の tmux セッション方針（tmux 内・VSCode 内は除外。`main` が他ウィンドウで使用中＝クライアント接続済みなら独立セッション `win-<pid>` を作り、`client-attached` フックで `destroy-unattached on` を貼って閉じたら自動破棄。未使用時は `main` に attach＝無ければ作成）、nodenv 初期化。
+  - `config.fish`: starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動）、起動時の tmux セッション方針（tmux 内・VSCode 内は除外。`main` が他ウィンドウで使用中＝クライアント接続済みなら独立セッション `win-<pid>` を作り、`client-attached` フックで `destroy-unattached on` を貼って閉じたら自動破棄。未使用時は `main` に attach＝無ければ作成）、nodenv 初期化。
   - `conf.d/`: fzf 関連のキーバインド（`fzf_cd_keybind`=Ctrl-O, `fzf_tab_complete`=Tab, `ghq_fzf_keybind`=Ctrl-G）。`config.fish` の `fzf --fish` で定義される widget に bind しているため、読み込み順序に依存する。
   - `functions/`: `ghq_fzf`（ghq リポジトリを fzf 選択して cd）、`ll`/`ls`（eza ラッパ）。
   - プラグインマネージャは使っていない（旧 fisherman 構成は廃止）。
@@ -38,7 +38,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 ## 横断的な約束ごと
 
 - 配色は ghostty テーマ **"Material Design Colors"** に統一されている。fish の `FZF_*` 配色、`.tmux.conf` のステータスライン、`starship.toml` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 3 箇所を揃える。
-- 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`, `git-wt`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。
+- 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。
 
 ## 注意点
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 
 | 対象 | パス | 概要 |
 | --- | --- | --- |
-| **fish** | `.config/fish/` | starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動 / Ctrl-G ghq）、git-wt 統合（`git wt <branch>` で worktree 切替 cd・補完）、起動時の tmux 自動アタッチ（`main` セッション。tmux 内・VSCode 内は除外）、nodenv 初期化。`conf.d/` に fzf 関連キーバインド、`functions/` に `ghq_fzf` と eza ラッパ（`ll`/`ls`）。プラグインマネージャは未使用。 |
+| **fish** | `.config/fish/` | starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動 / Ctrl-G ghq）、起動時の tmux 自動アタッチ（`main` セッション。tmux 内・VSCode 内は除外）、nodenv 初期化。`conf.d/` に fzf 関連キーバインド、`functions/` に `ghq_fzf` と eza ラッパ（`ll`/`ls`）。プラグインマネージャは未使用。 |
 | **tmux** | `.tmux.conf` | tmux 3.6+ 前提。prefix は `Ctrl-a`。ghostty 連携のため CSI u 拡張キーや truecolor を明示設定。 |
 | **ghostty** | `.config/ghostty/config` | フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。Cmd 系キーを tmux のプレフィックスシーケンスに変換するキーバインドを持つ。 |
 | **herdr** | `.config/herdr/config.toml` | ワークスペース/タブ/ペイン・エージェント管理ツールの設定。テーマ・トースト通知・UI 表示のみ追跡。セッション状態（`session.json`）とログ（`*.log`）は `.gitignore` で除外。 |
@@ -52,7 +52,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 
 ## 依存コマンド
 
-`starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`, `git-wt`。
+`starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `tmux`。
 
 いずれも `.Brewfile` に含まれる。未インストールでも該当機能が無効になるだけで、致命的には壊れない作りにしてある。
 


### PR DESCRIPTION
## 概要

- `git-wt`（worktree 切替 CLI）の統合を全廃する（#33）
- 関連する「worktree skill」は #24 で除去済みで、本PRは残っていた `git-wt` 本体の統合（fish シェル統合・Brewfile・Claude Code の permissions allowlist・ドキュメント記述）を対象とする
- `brew uninstall k1low/tap/git-wt` は既に未インストール状態だったため対象外。他に依存 formula がないことを確認した上で `brew untap k1low/tap` を実行済み（ローカル環境の作業でありコミット対象外）

## 変更内容

- `.config/fish/config.fish`: git-wt シェル統合ブロック（`if type -q git-wt` ガード）を削除
- `.Brewfile`: `brew "k1low/tap/git-wt"` の行を削除
- `.claude/settings.json`: permissions allowlist から `Bash(git wt:*)` / `Bash(git-wt:*)` を削除
- `CLAUDE.md`, `README.md`: git-wt に関する記述を削除

## 検証

- [x] `rg -i 'git-wt|git wt'` がリポジトリ内でヒットしないこと
- [x] `jq . .claude/settings.json` で有効なJSONであることを確認
- [x] `fish -n .config/fish/config.fish` で構文エラーがないことを確認
- [x] `~/.config`・`~/.claude` はディレクトリ自体がリポジトリへのシンボリックリンクのため、変更は即座に反映される

Closes #33
