### PR TITLE
chore(herdr): unify theme with Material Design Colors palette

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -32,8 +32,26 @@ description = "State-dependent close: pane > tab > workspace, with confirmation"
 command = "sh -c '\"$HOME\"/.config/herdr/scripts/herdr-cmd-w.sh'"
 
 [theme]
-name = "solarized"
+name = "catppuccin"
 auto_switch = false
+
+[theme.custom]
+panel_bg    = "#1d262a"  # bg
+surface_dim = "#1d262a"
+surface0    = "#2a363b"  # FZF bg+
+surface1    = "#435b67"  # border
+overlay0    = "#4e6a78"  # selection
+overlay1    = "#a1b0b8"  # dim
+text        = "#e7ebed"  # fg
+subtext0    = "#a1b0b8"  # dim
+blue        = "#37b6ff"
+green       = "#5cf19e"
+yellow      = "#fed032"
+red         = "#fc3841"
+mauve       = "#fc669b"  # magenta
+teal        = "#59ffd1"  # cyan
+peach       = "#fc746d"
+accent      = "#37b6ff"
 
 [ui.toast]
 delivery = "system"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはな
 
 ## 横断的な約束ごと
 
-- 配色は ghostty テーマ **"Material Design Colors"** に統一されている。fish の `FZF_*` 配色と `starship.toml` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 2 箇所を揃える。
+- 配色は ghostty テーマ **"Material Design Colors"** に統一されている。fish の `FZF_*` 配色、`starship.toml`、herdr の `.config/herdr/config.toml` の `[theme.custom]` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 3 箇所を揃える。
 - 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。
 
 ## 注意点

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 
 ## 配色
 
-ghostty テーマ **"Material Design Colors"** に統一している。fish の `FZF_*` 配色と `starship.toml` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 2 箇所を揃える。
+ghostty テーマ **"Material Design Colors"** に統一している。fish の `FZF_*` 配色、`starship.toml`、herdr の `.config/herdr/config.toml` の `[theme.custom]` が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときは 3 箇所を揃える。
 
 ## 注意点
 


### PR DESCRIPTION
## Summary
- herdr のテーマをビルトイン `solarized` から `catppuccin` ベース + `[theme.custom]` に変更し、Material Design Colors パレットの16トークン（`panel_bg`/`surface0`/`surface1`/`surface_dim`/`overlay0`/`overlay1`/`text`/`subtext0`/`blue`/`green`/`yellow`/`red`/`mauve`/`teal`/`peach`/`accent`）で上書き
- `CLAUDE.md` / `README.md` の配色共有箇所の記述を「2箇所（fish `FZF_*` / `starship.toml`）」→「3箇所（+ herdr）」に更新
- closes #30

## Test plan
- [x] `~/.config/herdr/config.toml`（symlink 経由でリポジトリと同一実体）へ反映後 `herdr server reload-config` を実行し、`outcome="ok"` をログで確認
- [x] herdr のパネル背景・ボーダー・アクセントカラーが ghostty の他ペインと視覚的に統一されていることを目視確認
- [x] `rg -n "2 箇所" CLAUDE.md README.md` がヒットしないことを確認
