### PR TITLE
chore(skills): merge commit skill with Mac-local version

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: commit
-description: "git commit を作成・提案する時に使う。Conventional Commits 形式（type(scope): subject）、subject の規約（英語・命令形・小文字始まり・末尾ピリオドなし・50〜72 文字目安）、絵文字禁止、破壊的変更の feat! / BREAKING CHANGE 表記を適用する。コミットメッセージを書く場面で発動する。"
+description: "git commit を作成する時に使う。Conventional Commits 形式（type(scope): subject）・英語・命令形・小文字始まり・末尾ピリオドなし・50〜72 文字目安・1 行完結、絵文字禁止・AI co-author 禁止のコミットメッセージを作成してコミットする。コミットメッセージを書く場面で発動する。"
 user-invocable: true
-allowed-tools: "Bash(git:*)"
+allowed-tools: "Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*)"
 ---
 
 # コミット規約
 
-git commit を作成・提案するときに従う規約。これがコミットメッセージ規約の単一の source of truth。
+git commit を作成するときに従う規約。これがコミットメッセージ規約の単一の source of truth。
 
 ## 優先順位
 
@@ -32,7 +32,8 @@ git commit を作成・提案するときに従う規約。これがコミット
 ## subject の規約
 
 - **英語**・**命令形**・**小文字始まり**・**末尾ピリオドなし**。
-- 件名は **50〜72 文字以内**を目安にする。
+- **50〜72 文字以内**を目安にする。
+- **1 行で完結させる**。試行錯誤の経緯や実装の詳細は書かない。
 
 ## 破壊的変更
 
@@ -42,12 +43,33 @@ git commit を作成・提案するときに従う規約。これがコミット
 
 - **絵文字は使わない**。
 - **AI co-author credits は含めない**。
+- **箇条書きで実装詳細を列挙しない**（冗長なコミットメッセージを避ける）。
 
-## 実行フロー（Fail-Safe）
+## 実行フロー
 
-- 作業が一区切りしたら commit を**提案**する。実行はユーザーの確認後に行い、勝手に commit しない。
+コミットする前に以下のステップを踏む。
+
+### Step 1: ステージ内容を確認する
 
 ```bash
-git add <paths>
+git diff --cached
+```
+
+変更の性質（新機能・バグ修正・リファクタ・ドキュメントなど）と影響範囲を把握する。
+
+### Step 2: 直近の commit 履歴でスタイルを確認する
+
+```bash
+git log --oneline -10
+```
+
+言語・構造・プレフィックス・文体の傾向を確認する。履歴が本スキルの規約と一致しない場合でも、本スキルの規約を優先する。
+
+### Step 3: コミットして報告する
+
+分析結果をもとに、シンプルで簡潔なコミットメッセージを作成してコミットする。
+コミット後、実行したメッセージをユーザーに報告する。
+
+```bash
 git commit -m "<type>(<scope>): <subject>"
 ```


### PR DESCRIPTION
## Summary

- `allowed-tools` を `Bash(git:*)` から個別サブコマンド指定（`git diff`, `git log`, `git add`, `git commit`）に変更し、明示的最小権限を適用
- subject 規約に「1 行完結・詳細不要」を追加
- 禁止事項に「箇条書きで実装詳細を列挙しない」を追加
- 実行フローを Fail-Safe（提案止まり）から Step1→2→3 の自動コミットフローに変更

Closes #35

## Test plan

- [ ] PR マージ後、`~/.claude/skills/commit/SKILL.md` に同内容をコピーする
- [ ] `/commit` を発動して Step1（`git diff --cached`）→ Step2（`git log --oneline -10`）→ Step3（`git commit`）が順に実行されることを確認する