### PR TITLE
chore: Brewfile を現在の環境と同期する

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -37,6 +37,8 @@ cask "font-udev-gothic-nf"
 cask "chatgpt"
 # Terminal emulator that uses platform-native UI and GPU acceleration
 cask "ghostty"
+# Desktop client for GitHub repositories
+cask "github"
 # Open-source code editor
 cask "visual-studio-code"
 npm "corepack"

--- a/.Brewfile
+++ b/.Brewfile
@@ -1,4 +1,3 @@
-tap "k1low/tap"
 # Clone of cat(1) with syntax highlighting and Git integration
 brew "bat"
 # Modern, maintained replacement for ls


### PR DESCRIPTION
## 変更内容

`brew bundle check --global` が通るよう、`.Brewfile` を現在の環境に合わせて2点修正した。

### GitHub Desktop を追加

`brew install --cask github` でインストール済みだったが、`.Brewfile` にエントリがなかった。
`cask "ghostty"` の直後（アルファベット順）に追記した。

### `k1low/tap` を削除

`brew untap k1low/tap` で untap 済みだったが、`.Brewfile` の先頭行にエントリが残っていた。
この tap 由来の formula も残っていないため、エントリごと削除した。

## 確認

`brew bundle check --global` がエラーなしでパスすることを確認済み。