### PR TITLE
feat(gitconfig): gitconfig に SSH 署名検証とタグ署名の設定を追加する

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -40,6 +40,10 @@
 	gpgsign = true
 [gpg]
 	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = ~/.ssh/allowed_signers
+[tag]
+	gpgsign = true
 [diff]
 	colorMoved = default
 [branch]


### PR DESCRIPTION
## 背景

この Mac の実 `~/.gitconfig` には、SSH 署名検証（`allowedSignersFile`）とタグ署名（`gpgsign`）の設定がすでに入っている。
しかし repo の `.gitconfig` には反映されておらず、他マシンでのブートストラップ時にこの設定が再現されない。

## 変更内容

`.gitconfig` の `[gpg] format = ssh` の直後に、実機と同じ並び順で以下を追記した。

```
[gpg "ssh"]
	allowedSignersFile = ~/.ssh/allowed_signers
[tag]
	gpgsign = true
```

キー名は repo 既存の `[commit] gpgsign = true` に合わせて小文字にした。
実機は `gpgSign` とキャメルケースで書かれているが、git config はキー名の大小を区別しないため、repo 内の表記の一貫性を優先した。

## 対象外

以下は今回のスコープ外として変更していない。

- `~/.ssh/allowed_signers`：署名者の実 identity を含むため対象外にした。
- `[credential "..."]` セクション：`gh` credential helper のパスをハードコードするため対象外にした。
- `[filter "lfs"]` セクション：本 issue のスコープ外。

## 検証

編集後の repo `.gitconfig` の `gpg.format` / `gpg.ssh.allowedSignersFile` / `tag.gpgsign` が、実機 `~/.gitconfig` の値と一致することを `git config -f` で確認した。
実機側はすでに設定済みで動作しているため、`~/.gitconfig` への追加の書き込みは行っていない。
他マシンへの反映は、既存のブートストラップ手順（CLAUDE.md 記載）に従う。

Closes #45