### PR TITLE
chore(gitignore): herdr のリリースノートキャッシュを無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # herdr が生成するマシン固有のセッション状態・ログ（config.toml のみ管理）
 .config/herdr/session.json
 .config/herdr/*.log
+.config/herdr/release-notes.json
 
 # ツールが生成する update-check キャッシュ（マシン固有・追跡不要）
 .config/configstore/


### PR DESCRIPTION
## Summary
- herdr が生成する `.config/herdr/release-notes.json`（マシン固有のキャッシュファイル）を `.gitignore` に追加

## Test plan
- [x] `git check-ignore -v .config/herdr/release-notes.json` で無視されることを確認
- [x] `git status --short` に該当ファイルが出ないことを確認