### PR TITLE
docs: README を正典化し CLAUDE.md をスリム化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,11 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+macOS 向けの個人 dotfiles。
+リポジトリのルートを `$HOME` のミラーとして扱い、各ファイルを `$HOME` 配下の同じパスへ手動配置して使う。
+ビルド・テスト・lint の仕組みはない。
 
-## 概要
+構成・ブートストラップ手順・配色・注意点・コミット規約は [README.md](README.md) を参照する。README がこのリポジトリの単一の正典であり、AI もそちらを読むこと。
 
-macOS 向けの個人 dotfiles。ビルド・テスト・lint の仕組みはない。リポジトリのルートを `$HOME` のミラーとして扱い、各ファイルを `$HOME` 配下の同じパスに配置（手動）して使う。リポジトリ自体は `ghq` で `~/Sites` 以下に管理される前提（`.gitconfig` の `ghq.root` 参照）。
+## AI 向けの運用メモ
 
-ファイルを編集したら、対応する `$HOME` の実ファイルへ反映しないと挙動は変わらない（自動同期の仕組みはない）。
-
-## 構成
-
-- **fish** (`.config/fish/`)
-  - `config.fish`: starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動）、起動時に herdr へアタッチ（herdr 内・VSCode 内は除外し、`herdr` を attach-or-create で起動）、nodenv 初期化。Homebrew と同様に `~/.local/bin`（Homebrew 非管理の単体バイナリの配置先）を毎起動 PATH へ追加し、`$EDITOR` に `nvim` を設定する。
-  - `conf.d/`: fzf 関連のキーバインド（`fzf_cd_keybind`=Ctrl-O, `fzf_tab_complete`=Tab, `ghq_fzf_keybind`=Ctrl-G）。`config.fish` の `fzf --fish` で定義される widget に bind しているため、読み込み順序に依存する。
-  - `functions/`: `ghq_fzf`（ghq リポジトリを fzf 選択して cd）、`ll`/`ls`（eza ラッパ）。
-  - プラグインマネージャは使っていない（旧 fisherman 構成は廃止）。
-- **ghostty** (`.config/ghostty/config`): フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。pane/tab/zoom/copy 操作は herdr が prefix（`Ctrl+a`）キーで自前処理するため ghostty 側のキー橋渡しは基本持たないが、`Cmd+T`/`Cmd+Shift+T`/`Cmd+Option+T`/`Cmd+W` の4つだけ `text:` アクションで herdr へ直接チョードを送出するブリッジを持つ（`.config/herdr/config.toml` の直接バインドと対で機能する）。`Cmd+Shift+N` は ghostty ネイティブの新規ウィンドウ。
-- **herdr** (`.config/herdr/config.toml`): ワークスペース/タブ/ペイン・エージェント管理ツールの設定。prefix は `[keys] prefix = "ctrl+a"` で上書きし、pane/tab/zoom 操作や copy mode（`prefix+[`→`v` 選択→`y` でクリップボードへ）は herdr 既定キーで運用する（split は `new_cwd = "follow"` 既定で親の cwd を継承）。ghostty の Cmd ショートカット橋渡し用の直接チョードと、`Cmd+W` 用の状態依存クローズスクリプト（`.config/herdr/scripts/herdr-cmd-w.sh`）も追加済み。テーマ・トースト通知・UI 表示・キー設定のみ追跡し、セッション状態（`session.json`）とログ（`herdr-server.log`／`herdr-client.log`）は `.gitignore` で除外する。Claude Code の SessionStart フック（`~/.claude/hooks/herdr-agent-state.sh`）と連携してエージェント状態を herdr へ通知する（フック実体は `~/.claude/hooks/` 配下でマシンローカル・追跡外）。
-- **nvim** (`.config/nvim/`): [LazyVim](https://github.com/LazyVim/LazyVim) の [starter](https://github.com/LazyVim/starter) をベースに導入（Neovim >= 0.11.2 が必要）。追跡対象は `init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`（プラグインのバージョン固定）・`stylua.toml`・`.neoconf.json`・`lazyvim.json`（`:LazyExtras` の選択状態・news 既読状態）のみで、starter 同梱の `README.md`/`LICENSE`/`.gitignore` は削除済み（追跡しない）。colorscheme は [material.nvim](https://github.com/marko-cerovac/material.nvim) の "Deep Ocean" スタイル（`lua/plugins/colorscheme.lua` で `opts.colorscheme = "material-deep-ocean"`）で、ghostty の配色とは独立している。Markdown プレビューは `lazyvim.json` で有効化した `lang.markdown` extra による render-markdown.nvim（テーブル・コードブロック・frontmatter のバッファ内装飾）と、mermaid は markdown-preview.nvim（`<leader>cp`、ブラウザ表示、mermaid.js を同梱しクライアントサイドで描画）を使う。snacks.image による Kitty graphics protocol 経由のインライン描画は herdr pane 内では非対応と確認済みのため採用していない。プラグイン実体・parser・キャッシュは `~/.local/share|state|cache/nvim`（repo 外）に置かれ `.config/nvim/` 配下には出ない。pane 間の移動は herdr のキーバインドに一本化し、nvim 側の pane ナビゲーション連携（`herdr.nvim` 等）は入れない。nvim split 内の移動は Vim 既定（`Ctrl-w h/j/k/l`）に任せる。Claude Code との連携は `lazyvim.plugins.extras.ai.claudecode` extra で有効化した `claudecode.nvim` を使う。WebSocket サーバーを自動起動して Claude Code CLI と連携し、キーバインドは LazyVim extra のデフォルト（`<leader>a*`）を使用する。有効化済み extras（`lazyvim.json`）は `lang.markdown`・`ai.claudecode` のほか、`lang.typescript`・`formatting.prettier`・`lang.json`・`lang.yaml`・`lang.tailwind`・`lang.docker`・`lang.git`・`test.core` を含む。テストランナーは `test.core` extra に加え `lua/plugins/test.lua` で neotest-vitest adapter を追加している。
-- **starship** (`.config/starship.toml`): 2 行構成プロンプト。Nerd Font グリフ前提。
-- **tig** (`.tigrc`): git 操作を tig 上で完結させる大量のカスタムキーバインド。差分表示に **delta**、GitHub 連携（`;` `w`）に **gh** を使う。
-- **gh** (`.config/gh/config.yml`): 設定のみ。認証情報 (`hosts.yml`) は `.gitignore` で除外。
-- **git** (`.gitconfig`, `.gitignore_global`)
-- **zsh** (`.zprofile`, `.zshrc`): fish へ移行する前のログインシェル設定（brew shellenv / PATH のみ）。
-- **Homebrew** (`.Brewfile`): インストール済みの CLI ツール・GUI アプリ・フォントの一覧（`brew bundle --global` の既定パス `~/.Brewfile` のミラー）。`brew bundle dump --describe --no-vscode` で再生成する。VS Code 拡張は意図的に含めない。
-- **Claude Code** (`.claude/`): 追跡対象は下記のみ（`.gitignore` は whitelist 方式: `.claude/*` を無視し、各エントリを per-entry で再 include）。
-  - `CLAUDE.md`、`settings.json`（permissions allowlist・SessionStart フック・`enabledPlugins`）
-  - `agents/tdd-expert`（サブエージェント）
-  - `skills/commit`、`skills/japanese-tech-writing`、`skills/typescript-conventions`（skill 実体）
-  - `skills/herdr`、`skills/find-skills`（`.agents/skills/` への相対 symlink。クロスエージェント共用）
-  - plugins・ログ・キャッシュ・セッション・`settings.local.json` は追跡しない。plugins 実体は各マシンで `claude plugin install` または起動時に取得し、`settings.json` の `enabledPlugins` で宣言のみ管理する。
-  - `~/.agents` を本 repo の `.agents` への symlink にすると、`find-skills` インストーラや他エージェントが同じ実体を共有できる。
-
-## ブートストラップ（新しい Mac での再現手順）
-
-1. Homebrew をインストールする。
-2. このリポジトリの各ファイルを `$HOME` 配下の同じパスに配置する（`.Brewfile` → `~/.Brewfile` を含む）。
-3. `brew bundle --global` で `~/.Brewfile` のツール・アプリ・フォントを一括インストールする。
-4. neovim を Brewfile 経由で導入後、LazyVim starter を導入する（`git clone https://github.com/LazyVim/starter ~/.config/nvim` → `rm -rf ~/.config/nvim/.git` → starter 同梱の `README.md`/`LICENSE`/`.gitignore` を削除 → `nvim` を起動し初回の Lazy 同期を待つ）。同期後の `~/.config/nvim` がリポジトリの `.config/nvim/`（`init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`・`stylua.toml`・`.neoconf.json`・`lazyvim.json`）と一致することを確認する。
-5. fish をデフォルトシェルにする（`echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells; chsh -s /opt/homebrew/bin/fish`）。
-6. Node は **最新の LTS 版**を nodenv で入れてグローバル既定にする（`nodenv install --list` で最新 LTS を確認 → `nodenv install <version>` → `nodenv global <version>`）。バージョンは固定しない。
-7. `gh auth login` で GitHub 認証を行う（`hosts.yml` は追跡していないため各マシンで実施）。
-
-## 横断的な約束ごと
-
-- 配色は ghostty テーマ **"Material Design Colors"** に統一されている。fish の `FZF_*` 配色、`starship.toml`、herdr の `.config/herdr/config.toml` の `[theme.custom]` の3箇所が同じ HEX 値（例: bg `#1d262a` / 青 `#37b6ff`）を共有しているので、色を変えるときはこの3箇所を揃える。nvim（material.nvim の Deep Ocean）はこのパレットとは独立した配色を採用しており、同期対象ではない。
-- 依存コマンド: `starship`, `fzf`, `fd`, `eza`, `bat`, `delta`, `gh`, `ghq`, `jq`, `nodenv`, `rg`, `nvim`。未インストールでも該当機能が無効になるだけで致命的には壊れない作りにしてある。全て `.Brewfile` に含まれる。
-
-## 注意点
-
-- `.gitignore` で `fish_variables`（fish が生成するマシン固有状態）と `gh/hosts.yml`（認証トークン）を除外している。これらはコミットしない。
-- `.gitconfig` の `user.email` は公開用のダミーアドレス。実アドレスを入れない。
-- コミットメッセージは **Conventional Commits** 形式（`<type>(<scope>): <subject>`）に従う。subject は**英語**・命令形・小文字始まり・末尾ピリオドなし。絵文字は使わない。
+- ファイルを編集したら、対応する `$HOME` のパスへ**手動でコピー**して反映しないと挙動は変わらない（自動同期の仕組みはない）。

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
 | 対象 | パス | 概要 |
 | --- | --- | --- |
 | **fish** | `.config/fish/` | starship プロンプト初期化、fzf シェル統合（Ctrl-R 履歴 / Ctrl-T ファイル / Ctrl-O ディレクトリ移動 / Ctrl-G ghq）、起動時に herdr へアタッチ（herdr 内・VSCode 内は除外）、nodenv 初期化。`~/.local/bin` を PATH へ追加し `$EDITOR` に `nvim` を設定。`conf.d/` に fzf 関連キーバインド、`functions/` に `ghq_fzf` と eza ラッパ（`ll`/`ls`）。プラグインマネージャは未使用。 |
-| **ghostty** | `.config/ghostty/config` | フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。pane/tab/zoom/copy 操作は herdr が prefix（`Ctrl+a`）キーで自前処理するため、ghostty 側のキー橋渡しは持たない。キーバインドは ghostty ネイティブの `Cmd+Shift+N`（新規ウィンドウ）のみ。 |
-| **herdr** | `.config/herdr/config.toml` | ワークスペース/タブ/ペイン・エージェント管理ツールの設定。テーマ・トースト通知・UI 表示のみ追跡。セッション状態（`session.json`）とログ（`*.log`）は `.gitignore` で除外。 |
-| **nvim** | `.config/nvim/` | [LazyVim](https://github.com/LazyVim/LazyVim) の [starter](https://github.com/LazyVim/starter) をベースに導入（Neovim >= 0.11.2 が必要）。追跡対象は `init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`・`stylua.toml`・`.neoconf.json`・`lazyvim.json`（`:LazyExtras` の選択状態・news 既読状態）・`colors/ghostty-material.lua`（ghostty と同じ配色の colorscheme）のみで、starter 同梱の `README.md`/`LICENSE`/`.gitignore` は削除して追跡しない。Markdown プレビューは `lang.markdown` extra（render-markdown.nvim）でテーブル・コードブロック・frontmatter をバッファ内装飾し、mermaid は markdown-preview.nvim（`<leader>cp`、ブラウザ表示）で見る。snacks.image による Kitty graphics protocol 経由のインライン描画は herdr pane 内では非対応のため採用していない。プラグイン実体・parser・キャッシュは `~/.local/share|state|cache/nvim`（repo 外）。pane 間の移動は herdr のキーバインドに一本化し、nvim 側の pane ナビゲーション連携は持たない。Claude Code とは隣の herdr pane で `claude` を起動する運用で連携し、nvim 側プラグインは追加しない。 |
+| **ghostty** | `.config/ghostty/config` | フォント `UDEV Gothic NF`、テーマ `Material Design Colors`。pane/tab/zoom/copy 操作は herdr が prefix（`Ctrl+a`）で自前処理するため、ghostty 側のキー橋渡しは基本持たない。例外は `Cmd+T`／`Cmd+Shift+T`／`Cmd+Option+T`／`Cmd+W` の 4 つで、`text:` アクションで固有のバイト列を herdr へ送って split/new_tab/close を起動する（herdr 側の直接バインドと対で機能する）。`Cmd+Shift+N` は ghostty ネイティブの新規ウィンドウ。 |
+| **herdr** | `.config/herdr/config.toml` | ワークスペース/タブ/ペイン・エージェント管理ツールの設定。prefix は `Ctrl+a`。pane/tab/zoom と copy mode（`prefix+[`→`v`→`y`）は herdr 既定キーで運用する。ghostty の `Cmd+*` ブリッジを受ける直接バインドと、`Cmd+W` 用の状態依存クローズスクリプトを持つ。追跡するのはテーマ・トースト通知・UI 表示・キー設定のみ。セッション状態（`session.json`）とログ（`*.log`）は `.gitignore` で除外。Claude Code の SessionStart フックと連携してエージェント状態を herdr へ通知する。 |
+| **nvim** | `.config/nvim/` | [LazyVim](https://github.com/LazyVim/LazyVim) の [starter](https://github.com/LazyVim/starter) をベースに導入（Neovim >= 0.11.2 が必要）。追跡対象は `init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`・`stylua.toml`・`.neoconf.json`・`lazyvim.json` のみ。starter 同梱の `README.md`/`LICENSE`/`.gitignore` は削除して追跡しない。colorscheme は material.nvim の "Deep Ocean"（`lua/plugins/colorscheme.lua`、ghostty とは独立）。有効な `:LazyExtras` は `lang.typescript`・`lang.markdown`・`formatting.prettier`・`lang.json`・`lang.yaml`・`lang.tailwind`・`lang.docker`・`lang.git`・`test.core`・`ai.claudecode`。Markdown プレビューは `lang.markdown`（render-markdown.nvim）でバッファ内装飾し、mermaid は markdown-preview.nvim（`<leader>cp`、ブラウザ表示）で見る。テストランナーは `test.core` に neotest-vitest adapter を追加。Claude Code とは `ai.claudecode` extra の claudecode.nvim（WebSocket 連携、キーは `<leader>a*`）で連携する。snacks.image の Kitty graphics inline 描画は herdr pane 非対応のため使わない。プラグイン実体・parser・キャッシュは repo 外（`~/.local/share|state|cache/nvim`）。pane 間の移動は herdr のキーバインドに一本化し、nvim 側の pane ナビゲーション連携は持たない。 |
 | **starship** | `.config/starship.toml` | 2 行構成プロンプト。Nerd Font グリフ前提。 |
 | **tig** | `.tigrc` | git 操作を tig 上で完結させるカスタムキーバインド。差分表示に [delta](https://github.com/dandavison/delta)、GitHub 連携に `gh` を使う。 |
 | **gh** | `.config/gh/config.yml` | 設定のみ。認証情報（`hosts.yml`）は `.gitignore` で除外。 |
 | **git** | `.gitconfig`, `.gitignore_global` | delta pager・alias 等。`user.email` は公開用ダミー。 |
 | **zsh** | `.zprofile`, `.zshrc` | fish 移行前のログインシェル設定（brew shellenv / PATH のみ）。 |
-| **Homebrew** | `.Brewfile` | インストール済み CLI ツール・GUI アプリ・フォントの一覧（`~/.Brewfile` のミラー）。VS Code 拡張は意図的に含めない。 |
-| **Claude Code** | `.claude/` | グローバル個人設定（`CLAUDE.md`）・エディタ設定（`settings.json`: permissions allowlist・Stop / SessionStart フック・有効プラグイン宣言 `enabledPlugins`）・サブエージェント（`agents/`）・skills（`skills/`）を追跡。プラグインの実体（`~/.claude/plugins/`）や会話ログ・キャッシュ・セッション等のマシン固有/機密データは除外し、settings.json で宣言のみ追跡する。 |
+| **Homebrew** | `.Brewfile` | インストール済み CLI ツール・GUI アプリ・フォントの一覧（`~/.Brewfile` のミラー）。`brew bundle dump --describe --no-vscode` で再生成する。VS Code 拡張は意図的に含めない。 |
+| **Claude Code** | `.claude/` | グローバル個人設定（`CLAUDE.md`）・エディタ設定（`settings.json`: permissions allowlist・SessionStart フック・有効プラグイン宣言 `enabledPlugins`）・サブエージェント（`agents/`）・skills（`skills/`）を追跡。プラグインの実体（`~/.claude/plugins/`）や会話ログ・キャッシュ・セッション等のマシン固有/機密データは除外し、settings.json で宣言のみ追跡する。 |
 | **共用 skill** | `.agents/` | クロスエージェント共用 skill（`herdr` / `find-skills`）の実体。`.claude/skills/` からはリポジトリ内相対の symlink（`../../.agents/skills/...`）で参照し、マシン固有の絶対パスを埋め込まない。`~/.agents` も本 repo の `.agents` への symlink にすると、find-skills インストーラや他エージェントが同じ実体を共有する。インストーラ生成の `.skill-lock.json`（マシン固有）は除外する。 |
 
 ## ブートストラップ（新しい Mac での再現手順）
@@ -32,7 +32,7 @@ macOS 向けの個人 dotfiles。リポジトリのルートを `$HOME` のミ�
    rm -rf ~/.config/nvim/.git
    nvim   # 初回起動で lazy.nvim がプラグインを同期する
    ```
-   同期完了後、`~/.config/nvim` 配下がこのリポジトリの `.config/nvim/`（`init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`・`stylua.toml`・`.neoconf.json`・`lazyvim.json`・`colors/ghostty-material.lua`）と一致していることを確認する（starter 同梱の `README.md`/`LICENSE`/`.gitignore` は削除する）。C コンパイラ（`nvim-treesitter` 用）は Xcode Command Line Tools で充足するため、未導入なら `xcode-select --install` を先に実行する。
+   同期完了後、`~/.config/nvim` 配下がこのリポジトリの `.config/nvim/`（`init.lua`・`lua/config/*`・`lua/plugins/*`・`lazy-lock.json`・`stylua.toml`・`.neoconf.json`・`lazyvim.json`）と一致していることを確認する（starter 同梱の `README.md`/`LICENSE`/`.gitignore` は削除する）。C コンパイラ（`nvim-treesitter` 用）は Xcode Command Line Tools で充足するため、未導入なら `xcode-select --install` を先に実行する。
 5. fish をデフォルトシェルにする。
    ```sh
    echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells
@@ -73,7 +73,8 @@ ghostty テーマ **"Material Design Colors"** に統一している。fish の 
 ## 注意点
 
 - `.gitignore` で `fish_variables`（fish が生成するマシン固有状態）と `gh/hosts.yml`（認証トークン）を除外している。これらはコミットしない。
-- `~/.claude/plugins/`（プラグインの実体・キャッシュ・`installed_plugins.json` 等）は `.gitignore` 対象でコミットしない。各マシンでブートストラップ手順 7 により取得する。
+- `.claude/settings.json` は追跡対象だが、Claude Code の `/model` コマンドが書き込む `model` キーはマシン/セッション固有なのでコミットしない。
+- `~/.claude/plugins/`（プラグインの実体・キャッシュ・`installed_plugins.json` 等）は `.gitignore` 対象でコミットしない。各マシンでブートストラップ手順 8 により取得する。
 - `.agents/.skill-lock.json`（skill インストーラが生成するマシン固有の状態）は `.gitignore` 対象でコミットしない。`.agents/skills/` の実体のみ追跡する。
 - `.gitconfig` の `user.email` は公開用のダミーアドレス。実アドレスを入れない。
 - コミットメッセージは [Conventional Commits](https://www.conventionalcommits.org/) 形式（`<type>(<scope>): <subject>`）に従う。


### PR DESCRIPTION
## 概要

`CLAUDE.md` と `README.md` の内容が大きく重複していたため、役割を分離して重複を解消した。

- **README.md**: 人間も AI も参照する単一の正典。構成・ブートストラップ・配色・注意点・コミット規約を集約した。
- **CLAUDE.md**: AI 向けの最小オリエンテーションに絞り、詳細は README を参照する形にした。

## 変更点

### 役割分離・重複排除

- CLAUDE.md から構成・ブートストラップ・横断的な約束ごと・注意点を削除し、README へ委譲した。
- CLAUDE.md はリポジトリの要約と README への参照、AI 向けの運用メモ（`$HOME` へは手動コピーで反映）のみを残した。

### 実装との乖離を修正

README を正典化するにあたり、実装から乖離していた記述を修正した。

- nvim: 存在しない `colors/ghostty-material.lua` を削除。colorscheme を material.nvim "Deep Ocean"、Claude Code 連携を `claudecode.nvim`（`ai.claudecode` extra）に修正し、有効 extras を実態に合わせた。
- ghostty: `Cmd+T`/`Cmd+Shift+T`/`Cmd+Option+T`/`Cmd+W` の 4 つの herdr ブリッジを記載した。
- Claude Code: `settings.json` のフックを実体どおり SessionStart のみに修正した。

### その他

- `.claude/settings.json` の `model` キー（`/model` が書き込むマシン/セッション固有の値）をコミットしない旨を README の「注意点」に追記した。
- `.Brewfile` の再生成コマンドを README に補い、注意点の手順番号の参照ミスを直した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)