### PR TITLE
feat(nvim): 行番号を hybrid 表示に変更し markdownlint-cli2 を無効化

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -2,4 +2,5 @@
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- Add any additional options here
 
-vim.opt.relativenumber = false
+vim.opt.number = true
+vim.opt.relativenumber = true

--- a/.config/nvim/lua/plugins/markdown.lua
+++ b/.config/nvim/lua/plugins/markdown.lua
@@ -5,4 +5,33 @@ return {
       ensure_installed = { "yaml", "mermaid" },
     },
   },
+  {
+    "mfussenegger/nvim-lint",
+    opts = function(_, opts)
+      opts.linters_by_ft = opts.linters_by_ft or {}
+      opts.linters_by_ft["markdown"] = {}
+      return opts
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    opts = function(_, opts)
+      opts.formatters_by_ft = opts.formatters_by_ft or {}
+      for _, ft in ipairs({ "markdown", "markdown.mdx" }) do
+        opts.formatters_by_ft[ft] = vim.tbl_filter(function(f)
+          return f ~= "markdownlint-cli2"
+        end, opts.formatters_by_ft[ft] or {})
+      end
+      return opts
+    end,
+  },
+  {
+    "mason-org/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = vim.tbl_filter(function(pkg)
+        return pkg ~= "markdownlint-cli2"
+      end, opts.ensure_installed or {})
+      return opts
+    end,
+  },
 }


### PR DESCRIPTION
## 変更内容

ライブ環境（`~/.config/nvim/`）でのみ反映されていた設定変更を、リポジトリへ取り込む。

### `lua/config/options.lua`

`relativenumber = false` を廃止し、絶対行番号と相対行番号を同時に有効化した。

```lua
vim.opt.number = true
vim.opt.relativenumber = true
```

現在行に絶対行番号、それ以外に相対行番号を表示する hybrid 表示になる。

### `lua/plugins/markdown.lua`

`markdownlint-cli2` を3つのプラグインから除外するオーバーライドを追加した。

- **nvim-lint**：`linters_by_ft["markdown"]` を空配列にしてリンターを無効化
- **conform.nvim**：`formatters_by_ft` の `markdown` / `markdown.mdx` から `markdownlint-cli2` を除外
- **mason.nvim**：`ensure_installed` から `markdownlint-cli2` を除外して自動インストールを抑制

## 検証

`diff -r ~/.config/nvim/ .config/nvim/` で差分ゼロを確認済み。