### PR TITLE
chore(gitignore): Claude Code の worktree ディレクトリを除外

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -4,3 +4,4 @@ thumbs.db
 node_modules/
 npm-debug.log
 **/.claude/settings.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- `.gitignore_global` に `**/.claude/worktrees/` を追加し、Claude Code のエージェント分離用 worktree ディレクトリをバージョン管理対象外にする

## Test plan
- [x] `core.excludesfile` が `~/.gitignore_global`（本リポジトリへのシンボリックリンク）を指していることを確認
- [x] 既存の `.claude/worktrees/` を持つ別リポジトリで `git status --ignored` により無視されることを確認