### PR TITLE
chore(herdr): herdr の通知配信方式をターミナル出力に変更しスクロールバッファ上限を設定する

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -54,8 +54,12 @@ peach       = "#fc746d"
 accent      = "#37b6ff"
 
 [ui.toast]
-delivery = "system"
+delivery = "terminal"
 
 [ui]
 show_agent_labels_on_pane_borders = false
 agent_panel_sort = "spaces"
+
+[advanced]
+advanced.scrollback_limit_bytes = 50000000
+


### PR DESCRIPTION
## 変更内容

dotfiles 管理元の `.config/herdr/config.toml` を `$HOME` 実体と同期する。

取り込む差分は2点。

- `[ui.toast] delivery` を `"system"` から `"terminal"` へ変更する。
- `[advanced]` セクションを末尾に追加し、`scrollback_limit_bytes = 50000000`（50 MB）を設定する。

## 背景

`$HOME/.config/herdr/config.toml`（実体）にはすでに上記の設定が反映されていた。
dotfiles 管理元との差分を解消して、リポジトリを実体の正典として維持する。

## 検証

変更後の dotfiles ファイルと `$HOME` 実体を `diff` で比較し、差分がゼロであることを確認した。