### PR TITLE
fix(herdr): scrollback_limit_bytes のキー重複を修正

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -61,5 +61,5 @@ show_agent_labels_on_pane_borders = false
 agent_panel_sort = "spaces"
 
 [advanced]
-advanced.scrollback_limit_bytes = 50000000
+scrollback_limit_bytes = 50000000
 


### PR DESCRIPTION
## Summary
- `[advanced]` テーブル内で `advanced.` プレフィックスが重複していたキー名を修正

## Test plan
- [ ] `.config/herdr/config.toml` を反映後、herdr でスクロールバック上限設定が読み込まれることを確認