### PR TITLE
feat(skills): add exoc-review and exoc-translate skills

### DIFF
--- a/.claude/skills/exoc-review/SKILL.md
+++ b/.claude/skills/exoc-review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: exoc-review
+description: "ローカル LLM サーバー (exocortex) にコードレビューを依頼する時に使う。git diff と関連ファイルを集めて Windows の GPU マシンへ送り、指摘を受け取る。「ローカルでレビューして」「exocortex でレビュー」などの依頼で発動する。"
+user-invocable: true
+allowed-tools: "Bash(exoc-review:*)"
+---
+
+# exoc-review
+
+`exoc-review` コマンドを実行してレビュー結果を受け取る。
+
+オプションは `exoc-review --help` で確認する。指定がなければ未コミットの変更をレビューする。
+
+`EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` が未設定の場合はその旨を伝えて終了する。勝手に値を推測しない。
+
+結果はそのまま提示する。指摘の取捨選択はユーザーが行う。ローカル LLM の指摘は誤りを含みうるので、明らかに誤っているものがあれば根拠を添えて指摘する。

--- a/.claude/skills/exoc-translate/SKILL.md
+++ b/.claude/skills/exoc-translate/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: exoc-translate
+description: "ローカル LLM サーバー (exocortex) に日英翻訳を依頼する時に使う。日本語から英語、英語から日本語へ翻訳する。「ローカルで翻訳して」「exocortex で翻訳」などの依頼で発動する。"
+user-invocable: true
+allowed-tools: "Bash(exoc-translate:*)"
+---
+
+# exoc-translate
+
+`exoc-translate` コマンドを実行して訳文を受け取る。翻訳方向は `--from` と `--to` で明示する。
+
+オプションは `exoc-translate --help` で確認する。改行を含む文章は標準入力から渡す。
+
+`EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` が未設定の場合はその旨を伝えて終了する。勝手に値を推測しない。
+
+訳文はそのまま提示する。自分で訳し直したり、体裁を整えたりしない。

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/commit/
+!.claude/skills/exoc-review/
+!.claude/skills/exoc-translate/
 !.claude/skills/japanese-tech-writing/
 !.claude/skills/tewake/
 !.claude/skills/typescript-conventions/


### PR DESCRIPTION
exocortex のローカル LLM サーバーを Claude Code から呼ぶための skill を 2 つ追加します。

対応する CLI 側の変更は haribote/exocortex#13 です。
そちらのマージ後でないと `exoc-review` と `exoc-translate` は動きません。

## 変更内容

- `.claude/skills/exoc-review/SKILL.md`
- `.claude/skills/exoc-translate/SKILL.md`
- `.gitignore` に 2 つの per-entry 除外解除

中身は薄くしています。
CLI のオプションを列挙すると、CLI 側の変更で skill が腐るためです。
オプションは `--help` を引かせます。

skill をリポジトリ本体（exocortex）ではなく dotfiles に置くのは、全リポジトリ横断で使う個人設定であり、特定プロダクトの持ち物ではないためです。
この方針は exocortex の `docs/design.md` に記載があります。

## 前提

`~/.local/bin/exoc-review` と `~/.local/bin/exoc-translate` にラッパースクリプトを置く必要があります。
手順は exocortex の `docs/implementation-plan.md` の Task 13 にあります。
ラッパーはマシン固有のパスを含むため、このリポジトリでは管理していません。

## 未検証

**実機との疎通を確認していません。**
`EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` が未設定で、Windows 機も起動していないためです。
skill が Claude Code に認識されること（`~/.claude` が dotfiles への symlink のため再起動なしで反映されました）と、`--help` が動くことまでは確認済みです。

## 補足

`CLAUDE.md` と `README.md` は「各ファイルを `$HOME` 配下の同じパスへ手動でコピーして反映する」と書いていますが、`~/.claude` は本リポジトリへの symlink であり、`.claude` 配下についてこの記述は誤っています。
本 PR の範囲外なので触っていません。
