### PR TITLE
feat(skills): exocortex の呼び出しを SSH トンネル経由にする

### DIFF
--- a/.claude/skills/exoc-review/SKILL.md
+++ b/.claude/skills/exoc-review/SKILL.md
@@ -1,16 +1,63 @@
 ---
 name: exoc-review
-description: "ローカル LLM サーバー (exocortex) にコードレビューを依頼する時に使う。git diff と関連ファイルを集めて Windows の GPU マシンへ送り、指摘を受け取る。「ローカルでレビューして」「exocortex でレビュー」などの依頼で発動する。"
+description: "ローカル LLM サーバー (exocortex) にコードレビューを依頼する時に使う。作業中リポジトリの snapshot を Windows の GPU マシンへ送り、指摘を受け取る。「ローカルでレビューして」「exocortex でレビュー」などの依頼で発動する。"
 user-invocable: true
-allowed-tools: "Bash(exoc-review:*)"
+allowed-tools: "Bash(git:*), Bash(tar:*), Bash(curl:*), Bash(mktemp:*), Bash(rm:*), Bash(ssh:*), Bash(pkill:*)"
 ---
 
 # exoc-review
 
-`exoc-review` コマンドを実行してレビュー結果を受け取る。
+ローカル LLM サーバー (exocortex) にコードレビューを依頼する。
+作業中リポジトリの snapshot をサーバーへ送り、サーバー側で diff と関連ファイルを組んでレビューさせる。
 
-オプションは `exoc-review --help` で確認する。指定がなければ未コミットの変更をレビューする。
+## 前提
 
-`EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` が未設定の場合はその旨を伝えて終了する。勝手に値を推測しない。
+`ssh exocortex` が通ること。
+通らなければその旨を伝えて終了する。設定を推測して直そうとしない。
 
-結果はそのまま提示する。指摘の取捨選択はユーザーが行う。ローカル LLM の指摘は誤りを含みうるので、明らかに誤っているものがあれば根拠を添えて指摘する。
+API は Windows の loopback にだけ publish されており、LAN からは届かない。
+SSH トンネルを張って `http://localhost:11435` を叩く。
+認証は SSH の公開鍵に委ねているため、リクエストに認証ヘッダは付けない。
+
+## 手順
+
+1. レビュー対象を決める。指定がなければ未コミットの変更。`params` にオプションを載せる。
+   - 未コミット: `{"language":"typescript"}`
+   - あるブランチからの差分: `{"language":"typescript","base":"main"}`
+   - ステージ済みのみ: `{"language":"typescript","staged":true}`
+   - `base` と `staged` は同時に指定できない。
+
+2. ディストロを起こしてトンネルを張り、snapshot を POST する（macOS 前提）。
+
+```bash
+ssh exocortex "wsl -d exocortex -- /bin/true"
+pkill -f "11435:127.0.0.1:11435"
+ssh -f -N -o ExitOnForwardFailure=yes -L 11435:127.0.0.1:11435 exocortex
+
+root=$(git rev-parse --show-toplevel)
+tmp=$(mktemp -d)
+tar --no-mac-metadata -czf "$tmp/snapshot.tgz" -C "$root" \
+  --null -T <(git -C "$root" ls-files -z --cached --others --exclude-standard) .git
+curl -sf \
+  -F 'params={"language":"typescript"}' \
+  -F "snapshot=@$tmp/snapshot.tgz;type=application/gzip" \
+  http://localhost:11435/review
+rm -rf "$tmp"
+pkill -f "11435:127.0.0.1:11435"
+```
+
+3. 返った JSON の `comments` をそのまま提示する。取捨選択はユーザーが行う。
+   `meta.droppedContextFiles` が 0 でなければ、予算に収めるため一部の context が落ちたことを添える。
+
+4. ローカル LLM の指摘は誤りを含みうる。明らかに誤っているものは根拠を添えて指摘する。
+
+## うまくいかないとき
+
+`curl` が接続を拒否されたら、ほぼディストロが停止している。
+idle が続くと WSL の VM ごと落ちるため、手順 2 の先頭で起こしている。
+それでも失敗する場合は `ssh exocortex "wsl -l -v"` で `Running` を確認してから張り直す。
+
+`413` が返ったら差分が大きすぎる。
+`base` を近いコミットにするなどで対象を絞る。
+
+トンネルを閉じ忘れたときは `pkill -f "11435:127.0.0.1:11435"` で閉じる。

--- a/.claude/skills/exoc-translate/SKILL.md
+++ b/.claude/skills/exoc-translate/SKILL.md
@@ -2,15 +2,52 @@
 name: exoc-translate
 description: "ローカル LLM サーバー (exocortex) に日英翻訳を依頼する時に使う。日本語から英語、英語から日本語へ翻訳する。「ローカルで翻訳して」「exocortex で翻訳」などの依頼で発動する。"
 user-invocable: true
-allowed-tools: "Bash(exoc-translate:*)"
+allowed-tools: "Bash(curl:*), Bash(jq:*), Bash(ssh:*), Bash(pkill:*)"
 ---
 
 # exoc-translate
 
-`exoc-translate` コマンドを実行して訳文を受け取る。翻訳方向は `--from` と `--to` で明示する。
+ローカル LLM サーバー (exocortex) に日英翻訳を依頼する。
 
-オプションは `exoc-translate --help` で確認する。改行を含む文章は標準入力から渡す。
+## 前提
 
-`EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` が未設定の場合はその旨を伝えて終了する。勝手に値を推測しない。
+`ssh exocortex` が通ること。
+通らなければその旨を伝えて終了する。設定を推測して直そうとしない。
 
-訳文はそのまま提示する。自分で訳し直したり、体裁を整えたりしない。
+API は Windows の loopback にだけ publish されており、LAN からは届かない。
+SSH トンネルを張って `http://localhost:11435` を叩く。
+認証は SSH の公開鍵に委ねているため、リクエストに認証ヘッダは付けない。
+
+## 手順
+
+1. 翻訳方向を決める。`from` と `to` は必須で、`ja` と `en` のどちらかである。
+   依頼文から明らかでなければユーザーに聞く。方向を推測しない。
+
+2. ディストロを起こしてトンネルを張り、POST する。
+   `FROM` と `TO` には手順 1 で決めた方向を入れる。下の値は日本語から英語への例にすぎない。
+   本文の JSON への埋め込みは `jq` に任せる。改行や引用符を自前でエスケープしない。
+
+```bash
+ssh exocortex "wsl -d exocortex -- /bin/true"
+pkill -f "11435:127.0.0.1:11435"
+ssh -f -N -o ExitOnForwardFailure=yes -L 11435:127.0.0.1:11435 exocortex
+
+FROM=ja
+TO=en
+jq -n --arg text "$TEXT" --arg from "$FROM" --arg to "$TO" \
+  '{text: $text, from: $from, to: $to}' |
+curl -sf -H 'Content-Type: application/json' --data-binary @- \
+  http://localhost:11435/translate
+pkill -f "11435:127.0.0.1:11435"
+```
+
+3. 返る JSON は `{"text": "..."}` である。
+   訳文はそのまま提示する。自分で訳し直したり、体裁を整えたりしない。
+
+## うまくいかないとき
+
+`curl` が接続を拒否されたら、ほぼディストロが停止している。
+idle が続くと WSL の VM ごと落ちるため、手順 2 の先頭で起こしている。
+それでも失敗する場合は `ssh exocortex "wsl -l -v"` で `Running` を確認してから張り直す。
+
+トンネルを閉じ忘れたときは `pkill -f "11435:127.0.0.1:11435"` で閉じる。


### PR DESCRIPTION
## 背景

exocortex 側の [PR #21](https://github.com/haribote/exocortex/pull/21) で、API の認証を Bearer トークンから SSH トンネルに移しました。
サーバーは Windows の loopback にだけ publish するようになり、LAN からは届きません。
この PR は、それに追従してクライアント側の skill を書き換えるものです。

`exoc-translate` はこれとは別の理由でも壊れていました。
exocortex の commit 5ebacbb で CLI が廃止されたのに、skill は `exoc-translate` コマンドを呼ぶままだったためです。
参照先の `apps/cli/dist/translate.js` は存在せず、実行すると `MODULE_NOT_FOUND` になります。
この機会にあわせて復旧します。

## 変更内容

両方の skill を、SSH トンネルを張って `http://localhost:11435` を叩く形にしました。
認証ヘッダは付けません。
`allowed-tools` に `Bash(ssh:*)` と `Bash(pkill:*)` を足しています。

`exoc-translate` は CLI の呼び出しをやめ、`/translate` への curl 直叩きに書き換えました。
本文の JSON への埋め込みは `jq` に任せ、改行や引用符を自前でエスケープしません。

前提の記述を `EXOCORTEX_ENDPOINT` と `EXOCORTEX_TOKEN` の有無から、`ssh exocortex` が通ることに変えました。
エンドポイントはトンネルのローカル側が決めるため、skill 側に固定で書いています。

## 設計方針からの逸脱

skill が WSL のディストロ名（`exocortex`）を知ることになりました。
exocortex の `docs/design.md` は「クライアントはサーバーの内部を知らない」という方針を掲げており、そこからの逸脱です。

承知のうえで受け入れます。
ディストロは idle が続くと WSL の VM ごと停止するため、リクエストの前に起こす主体がどこかに必要です。
サーバーは自分を起こせず、今それを担えるのは skill しかありません。
起こす処理を隠す wrapper script を dotfiles に置く案もありましたが、「クライアントは配布物を持たない」という別の方針と衝突するため採りませんでした。

## 検証

実機に対して両方の recipe を通しで実行しました。

- **`exoc-translate` の日英**: 改行を含む文章を投げ、200 と訳文が返りました。改行が保たれています。
- **`exoc-translate` の英日**: 200 と訳文が返りました。
- **`exoc-review`**: この PR の staged 差分を対象に投げ、200 が 31 秒で返りました（`inputTokens` 3303）。

`exoc-review` の検証では、レビュー結果がこの PR 自身の欠陥を 1 件指摘しました。
`exoc-translate` の例で翻訳方向が `ja` から `en` に固定されており、手順 1 の「方向を決める」と矛盾するという内容です。
妥当な指摘なので、`FROM` と `TO` を変数に出し、下の値が例にすぎないと明記する形に直しました。
その後で英日方向を実行し、通ることを確認しています。

### 未解決の事象

dotfiles リポジトリ全体の未コミット差分（235 行）を対象にしたレビューは、300 秒でサーバー側の推論タイムアウト（504）になりました。
`ollama ps` は `PROCESSOR: 100% GPU` で、ComfyUI も動いておらず、GPU の競合ではありません。
対象を staged 差分に絞れば 31 秒で返るため、転送や認証の問題ではなく、この入力に対する生成が長引いたものと見ています。
原因は特定できていません。
skill の変更に起因するものではないため、この PR では追いません。

## この PR に含まれない後片付け

リポジトリ管理外のため、次は手で行いました。

- fish の universal variable から `EXOCORTEX_TOKEN` を削除し、`EXOCORTEX_ENDPOINT` を `http://localhost:11435` に変更しました。トークンは `~/.config/fish/fish_variables` に平文で残っていたものです。
- `~/.local/bin/` の `exoc-review` と `exoc-translate` の shim を削除しました。どちらも存在しない `apps/cli/dist/` を指す死んだファイルでした。

`.claude/settings.json` などこの作業と無関係な未コミット変更は、ステージせず作業ツリーに残してあります。
