### PR TITLE
fix(exoc-skills): API のエラー本文を読めるようにする

### DIFF
--- a/.claude/skills/exoc-review/SKILL.md
+++ b/.claude/skills/exoc-review/SKILL.md
@@ -38,7 +38,7 @@ root=$(git rev-parse --show-toplevel)
 tmp=$(mktemp -d)
 tar --no-mac-metadata -czf "$tmp/snapshot.tgz" -C "$root" \
   --null -T <(git -C "$root" ls-files -z --cached --others --exclude-standard) .git
-curl -sf \
+curl -sS --fail-with-body \
   -F 'params={"language":"typescript"}' \
   -F "snapshot=@$tmp/snapshot.tgz;type=application/gzip" \
   http://localhost:11435/review
@@ -57,7 +57,13 @@ pkill -f "11435:127.0.0.1:11435"
 idle が続くと WSL の VM ごと落ちるため、手順 2 の先頭で起こしている。
 それでも失敗する場合は `ssh exocortex "wsl -l -v"` で `Running` を確認してから張り直す。
 
-`413` が返ったら差分が大きすぎる。
-`base` を近いコミットにするなどで対象を絞る。
+レビューが失敗したときは、`curl` が本文を出すのでそれを読んで伝える。
+
+- `413 context_too_large`：差分が大きすぎる。`base` を近いコミットにするなどで対象を絞る
+- `502 invalid_model_output`：モデルが schema に合う JSON を返さなかった。大きな入力で起きやすい。対象を絞って再試行する
+- `504 inference_timeout`：推論が 300 秒に収まらなかった。同じく対象を絞る
+
+いずれも入力を小さくすると通ることが多い。
+サーバーが入力に確保する上限は 20480 トークンで、思考の分を差し引いた残りである。
 
 トンネルを閉じ忘れたときは `pkill -f "11435:127.0.0.1:11435"` で閉じる。

--- a/.claude/skills/exoc-translate/SKILL.md
+++ b/.claude/skills/exoc-translate/SKILL.md
@@ -51,7 +51,7 @@ FROM=ja
 TO=en
 jq -n --arg text "$TEXT" --arg from "$FROM" --arg to "$TO" \
   '{text: $text, from: $from, to: $to}' |
-curl -Nsf -H 'Content-Type: application/json' --data-binary @- \
+curl -NsS --fail-with-body -H 'Content-Type: application/json' --data-binary @- \
   http://localhost:11435/translate > "$OUT"
 ```
 
@@ -71,6 +71,9 @@ jq -j 'select(.delta) | .delta' "$OUT"
    - `{"done":true,...}` があれば成功。delta を連結した全文が訳文である。
    - `{"error":...}` があれば失敗。`message` を添えてその旨を伝える。訳文は不完全なので提示しない。
    - `done` も `error` も無いままストリームが切れていたら、接続断として扱う。もう一度張り直す。
+
+   ストリームが始まる前に失敗した場合も、`$OUT` にエラーの body が入る。
+   `{"error":...}` として同じように扱えばよい。
 
 ```bash
 # Mac — 判定


### PR DESCRIPTION
## Summary

- `exoc-review` と `exoc-translate` の `curl` を `--fail-with-body` に変えた
- 失敗したときに、API が返すエラーの本文が読めるようになる
- `exoc-review` の「うまくいかないとき」に、実際に起こるエラーとその対処を並べた

## なぜ変えるのか

どちらの skill も `curl -sf`（translate は `-Nsf`）で API を叩いていた。
この組み合わせは、HTTP エラーのときに本文もエラーメッセージも一切出さない。

```
curl -sf   → exit=22, 出力なし
curl -s    → exit=0,  body=[404 Not Found]
curl -sS -f → exit=22, stderr に "The requested URL returned error: 404"
```

`-s` がエラーメッセージを黙らせ、`-f` が本文を捨てるためである。

exocortex 側は、クライアントが次の行動を選べる粒度でエラーを返している。
`{"error": "context_too_large", "message": "the diff alone exceeds the input budget"}` のような本文である。
`-sf` はそれを捨てていたので、skill は「何かに失敗した」ことしか伝えられなかった。

`exoc-review` の「うまくいかないとき」には「`413` が返ったら差分が大きすぎる」と書いてあるが、
`-sf` のままではステータスすら観測できないため、この案内自体が使えない状態だった。

## 変えたこと

### エラー本文を残す

両 skill の `curl` に `--fail-with-body` を渡し、`-s` を `-sS` にした。
失敗を非ゼロ終了で伝えつつ、`error` と `message` を読める。

`exoc-translate` は出力をファイルへリダイレクトしている。
ストリームが始まる前に失敗した場合、そのファイルにエラーの本文が入る。
判定の手順に、それを `{"error":...}` として同じように扱う旨を足した。

これまでは本文が捨てられるためファイルが空になり、「`done` も `error` も無いままストリームが切れた」経路に落ちて、接続断と誤診していた。

### 起こるエラーを列挙した

`exoc-review` の案内を、`413` だけから次の 3 つに広げた。

- `413 context_too_large`：差分が大きすぎる
- `502 invalid_model_output`：モデルが schema に合う JSON を返さなかった
- `504 inference_timeout`：推論が 300 秒に収まらなかった

いずれも大きな入力で起きやすく、対象を絞ると通ることが多い。
サーバーが入力に確保する上限が 20480 トークンであることも添えた。

## 動作確認

Mac から実機（exocortex）に対して、修正後のレシピをそのまま実行した。

**`/review` 成功系** — exit 0 でレビューが返り、仕込んだバグを `major` で 2 行目に検出した。

**`/review` 失敗系** — 不正な `base` を渡すと exit 22 で、次が読めた。

```
curl: (22) The requested URL returned error: 400
{"error":"invalid_request","message":"base does not resolve to a git ref: nope"}
```

**`/translate` 失敗系** — `to` を欠いたリクエストで exit 22 となり、リダイレクト先のファイルにエラー本文が入った。

`--fail-with-body` は curl 7.76 以降のオプションである。
手元の curl は 8.7.1 で、macOS の現行版であれば満たす。

## 関連

exocortex 側の `docs/api-reference.md` の正規レシピも同じ修正を入れてある（haribote/exocortex#24）。
この PR は、そのレシピを写している skill 側を揃えるものである。
