### PR TITLE
feat(nvim): show gitignored files in snacks explorer and files picker

### DIFF
--- a/.config/nvim/lua/plugins/explorer.lua
+++ b/.config/nvim/lua/plugins/explorer.lua
@@ -5,9 +5,11 @@ return {
       sources = {
         explorer = {
           hidden = true,
+          ignored = true,
         },
         files = {
           hidden = true,
+          ignored = true,
         },
       },
     },


### PR DESCRIPTION
## Summary

- `snacks.nvim` の `explorer` と `files` picker ソースに `ignored = true` を追加
- `.gitignore` に登録されたファイル・ディレクトリがファイルエクスプローラーに表示されるようになる

## Test plan

- [ ] nvim を再起動後、ファイルエクスプローラーで `.gitignore` に登録済みのファイル・ディレクトリが表示されることを確認
- [ ] `<leader><space>` の files picker でも同様に表示されることを確認