### PR TITLE
feat(exoc-review): fall back to per-file mode on a 504

### DIFF
--- a/.claude/skills/exoc-review/SKILL.md
+++ b/.claude/skills/exoc-review/SKILL.md
@@ -2,7 +2,7 @@
 name: exoc-review
 description: "ローカル LLM サーバー (exocortex) にコードレビューを依頼する時に使う。作業中リポジトリの snapshot を Windows の GPU マシンへ送り、指摘を受け取る。「ローカルでレビューして」「exocortex でレビュー」などの依頼で発動する。"
 user-invocable: true
-allowed-tools: "Bash(git:*), Bash(tar:*), Bash(curl:*), Bash(mktemp:*), Bash(rm:*), Bash(ssh:*), Bash(pkill:*)"
+allowed-tools: "Bash(git:*), Bash(tar:*), Bash(curl:*), Bash(jq:*), Bash(cat:*), Bash(mktemp:*), Bash(rm:*), Bash(ssh:*), Bash(pkill:*)"
 ---
 
 # exoc-review
@@ -28,6 +28,7 @@ SSH トンネルを張って `http://localhost:11435` を叩く。
    - `base` と `staged` は同時に指定できない。
 
 2. ディストロを起こしてトンネルを張り、snapshot を POST する（macOS 前提）。
+   status code は fallback の判定に使うので捨てない。
 
 ```bash
 ssh exocortex "wsl -d exocortex -- /bin/true"
@@ -38,18 +39,63 @@ root=$(git rev-parse --show-toplevel)
 tmp=$(mktemp -d)
 tar --no-mac-metadata -czf "$tmp/snapshot.tgz" -C "$root" \
   --null -T <(git -C "$root" ls-files -z --cached --others --exclude-standard) .git
-curl -sS --fail-with-body \
+code=$(curl -sS -o "$tmp/review.json" -w '%{http_code}' \
   -F 'params={"language":"typescript"}' \
   -F "snapshot=@$tmp/snapshot.tgz;type=application/gzip" \
-  http://localhost:11435/review
+  http://localhost:11435/review)
+cat "$tmp/review.json"
+```
+
+3. `code` が 200 なら、返った JSON の `comments` をそのまま提示する。取捨選択はユーザーが行う。
+   `meta.droppedContextFiles` が 0 でなければ、予算に収めるため一部の context が落ちたことを添える。
+
+4. `code` が 504 なら、同じ snapshot を per-file mode で投げ直す（下の「504 のときの fallback」を見る）。
+   それ以外のエラーでは投げ直さない。
+
+5. 最後に後始末をする。fallback を回すときは、それが終わってから実行する。
+
+```bash
 rm -rf "$tmp"
 pkill -f "11435:127.0.0.1:11435"
 ```
 
-3. 返った JSON の `comments` をそのまま提示する。取捨選択はユーザーが行う。
-   `meta.droppedContextFiles` が 0 でなければ、予算に収めるため一部の context が落ちたことを添える。
+6. ローカル LLM の指摘は誤りを含みうる。明らかに誤っているものは根拠を添えて指摘する。
 
-4. ローカル LLM の指摘は誤りを含みうる。明らかに誤っているものは根拠を添えて指摘する。
+## 504 のときの fallback
+
+`504 inference_timeout` は、モデルの thinking が暴走して 600 秒に収まらなかったことを示す。
+入力の大きさではなく thinking の長さで起きるので、同じ入力で投げ直しても直らないとは限らない。
+
+per-file mode は 1 ファイルずつ別々に推論するため、暴走したファイルだけを捨てて残りを返せる。
+**変更が 2 ファイル以上あるときだけ有効である。**
+1 ファイルしか変更していないなら、per-file の上限は 300 秒で whole の 600 秒より短く、通る見込みはかえって下がる。
+その場合は fallback せず、`base` を近いコミットにするなどで対象を絞るよう案内する。
+
+```bash
+curl -sS -N -o "$tmp/review.ndjson" \
+  -F 'params={"language":"typescript","mode":"per-file"}' \
+  -F "snapshot=@$tmp/snapshot.tgz;type=application/gzip" \
+  http://localhost:11435/review
+```
+
+応答は 1 行 1 JSON の ndjson になる。
+`{"heartbeat":true}` は接続の維持だけが目的なので読み飛ばす。
+
+```bash
+jq -c 'select(has("comments"))' "$tmp/review.ndjson"          # ファイルごとの結果
+jq -c 'select(has("file") and has("error"))' "$tmp/review.ndjson"  # 落ちたファイル
+jq -c 'select(has("done"))' "$tmp/review.ndjson"              # 件数の集計
+jq -c 'select(has("error") and (has("file") | not))' "$tmp/review.ndjson"  # run 全体の失敗
+```
+
+報告のしかたには、whole mode と違う注意が要る。
+
+- `done` の `failed` と `skipped` が 0 でなければ、**何ファイルがレビューされなかったかを必ず伝える**。
+  指摘が無いことと、レビューできなかったことは別である
+- `{"error":"all_files_failed"}` が返ったら、1 件もレビューできていない。「問題なし」と報告してはならない
+- per-file は削除されたファイルと、`language` の拡張子に合わないファイル（`.ts` `.tsx` `.js` `.jsx` 以外）を対象から外す。
+  これらは `skipped` に数えられる。設定ファイルや削除の差分を見たいときは whole mode で対象を絞り直す
+- `done` 行が無いまま終わっていたら、サーバーが ollama に到達できなくなった合図で、残りのファイルは未着手である
 
 ## うまくいかないとき
 
@@ -61,7 +107,8 @@ idle が続くと WSL の VM ごと落ちるため、手順 2 の先頭で起こ
 
 - `413 context_too_large`：差分が大きすぎる。`base` を近いコミットにするなどで対象を絞る
 - `502 invalid_model_output`：モデルが schema に合う JSON を返さなかった。大きな入力で起きやすい。対象を絞って再試行する
-- `504 inference_timeout`：推論が 300 秒に収まらなかった。同じく対象を絞る
+- `502 context_exhausted`：context window が尽きて生成が途中で切れた。原因はモデルではなく予算にあるので、対象を絞る
+- `504 inference_timeout`：推論が 600 秒に収まらなかった。per-file mode に落として投げ直す（上記）
 
 いずれも入力を小さくすると通ることが多い。
 サーバーが入力に確保する上限は 20480 トークンで、思考の分を差し引いた残りである。


### PR DESCRIPTION
## なぜ入れるのか

exocortex の `/review` は、thinking が暴走すると `504 inference_timeout` を返す。
これは入力の大きさではなく gemma4 系の縮退ループで起きるため、対象を絞っても避けられないことがある。

サーバー側に per-file mode が入った（exocortex#28、`8a92dee`、実機デプロイ済み）。
1 ファイルずつ推論するので、暴走したファイルだけを捨てて残りを返せる。
504 を受けたときの逃げ道として、この mode に落とす手順を skill に持たせる。

## 何を変えたか

status code を手元に残すようにした。
従来は `curl --fail-with-body` の出力を読むだけで、code が変数に入っていなかった。
`-o` でボディをファイルに落とし、`-w '%{http_code}'` で code を取る形にしてある。
後始末は fallback の後に回した。

504 のときだけ per-file mode で投げ直す。
snapshot は使い回すので tar は 1 回で済む。

ndjson の読み方を jq の selector 4 つで示した。
結果行、落ちたファイル、`done` の集計、run 全体の失敗を切り分ける。

## 1 ファイルの変更では落とさない

per-file の 1 呼び出しの上限は 300 秒で、whole の 600 秒より短い。
変更が 1 ファイルしかないなら捨てる先も残りも無いので、同じ暴走に対して半分の時間で諦めるだけになる。
その場合は fallback せず、`base` を近いコミットにするなどで対象を絞るよう案内させる。

## 報告のしかたに制約を課した

per-file mode は、レビューできなかったファイルがあっても HTTP 200 で返る。
`failed` を読まないと、指摘が無いことと、そもそも見ていないことの区別が付かない。

- `done` の `failed` と `skipped` が 0 でなければ、何ファイルがレビューされなかったかを必ず伝える
- `{"error":"all_files_failed"}` が返ったら「問題なし」と報告してはならない
- 削除されたファイルと `.ts` `.tsx` `.js` `.jsx` 以外は対象外で、`skipped` に数えられる
- `done` 行が無いまま終わったら、残りのファイルは未着手である

## 計測の裏付け

20 case を両モードで 1 回ずつ回した結果は exocortex#28 の本文にある。
要点は、完走率が 90% から 100% に上がり、検出はペア比較で拮抗し、総時間は 1.5 倍になることである。

## 併せて直したもの

エラー一覧の `504 inference_timeout` の説明を 900 秒から 600 秒にした。
サーバーの既定が下がったためである（exocortex#28 に含まれる）。

`allowed-tools` に `jq` と `cat` を足した。

## 検証できていないこと

**fallback の経路は実機で通していない。**
504 を起こすには thinking の暴走を引く必要があり、確率的で狙って再現できない。
jq の selector は手元の sample ndjson で確かめてあり、per-file mode 自体は実機で動作を確認している。

## 取り込んだ既存の変更

作業ツリーに未コミットで残っていた 1 行を含む。
エラー一覧に `502 context_exhausted` を足し、`504` の秒数を 300 から 900 に直す編集である。
同じ箇所を触るため分離しなかった。
