### PR TITLE
feat(lazygit): 設定を ~/.config 配下に移行し GUI 設定を調整

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -10,6 +10,9 @@ fish_add_path --path --prepend $HOME/.local/bin
 # 既定エディタ
 set -gx EDITOR nvim
 
+# lazygit の設定を ~/.config 配下に統一（macOS の既定は ~/Library/Application Support）
+set -gx CONFIG_DIR "$HOME/.config/lazygit"
+
 if status is-interactive
 # Commands to run in interactive sessions can go here
 

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,8 @@
+gui:
+  nerdFontsVersion: "3"
+  timeFormat: "2006-01-02 15:04"
+  shortTimeFormat: "15:04"
+git:
+  pagers:
+    - pager: delta --paging=never
+disableStartupPopups: true

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@
 
 # lazygit が生成するマシン固有の実行時状態（最近開いたリポジトリ、PR キャッシュ等）。
 # config.yml のみ管理する。
-Library/Application Support/lazygit/state.yml
+.config/lazygit/state.yml

--- a/Library/Application Support/lazygit/config.yml
+++ b/Library/Application Support/lazygit/config.yml
@@ -1,3 +1,0 @@
-git:
-  pagers:
-    - pager: delta --paging=never


### PR DESCRIPTION
## Summary

- lazygit の設定ファイルを macOS 既定の `Library/Application Support/lazygit/` から `.config/lazygit/` へ移行（`CONFIG_DIR` 環境変数を fish 設定に追加）
- Nerd Font アイコン表示、起動時ポップアップの無効化、日時表示形式（24時間表記・ISO風）などの GUI 設定を追加
- 移行に伴い `.gitignore` の runtime state ファイル除外パスを更新

## Test plan

- [ ] 新しい fish セッションで `lazygit` を起動し、`.config/lazygit/config.yml` の設定が読み込まれることを確認
- [ ] アイコン・日時表示・起動時ポップアップ非表示が反映されていることを確認