### PR TITLE
feat(genba-kantoku): worktree の作成先を .claude/worktree に固定

### DIFF
--- a/.claude/skills/genba-kantoku/SKILL.md
+++ b/.claude/skills/genba-kantoku/SKILL.md
@@ -50,7 +50,8 @@ herdr を使い、lead-agent（このセッション）が複数の helper-agent
 
 各 Wave で、並行させるサブタスクの数だけ以下を行う。**並行実行するため、複数の Bash 呼び出しを同一メッセージ内で発行する**（順に1つずつ呼ぶと並行にならない）。
 
-1. **worktree 作成**：`herdr worktree create --workspace <ID> --branch <branch-name> --base main --label "<label>" --no-focus`
+1. **worktree 作成**：`herdr worktree create --workspace <ID> --branch <branch-name> --base main --path .claude/worktree/<worktree-name> --label "<label>" --no-focus`
+   - `--path` は Claude Code 自身が worktree を作る際と同じディレクトリ規則（リポジトリ直下の `.claude/worktree/<worktree-name>`）に揃える。省略しない。
    - 重要な注意点は `references/herdr-gotchas.md` を参照。特に、これは「今の tab の新しい pane」ではなく**新しい workspace**を作る。ユーザーが特定の見た目（同一 tab 内の pane）を指示していた場合は、実際の挙動が異なることを一度確認する。
 2. **依存関係インストール**：`herdr pane run <PANE> "npm ci"`（プロジェクトに応じたコマンドに置き換える）→ `herdr pane wait-output <PANE> --regex "<完了を示す正規表現>" --timeout 180000` で完了を待つ。
 3. **helper-agent 起動**：`herdr agent start <name> --kind claude --pane <PANE> -- --permission-mode auto --model claude-sonnet-5`

--- a/.claude/skills/genba-kantoku/references/herdr-gotchas.md
+++ b/.claude/skills/genba-kantoku/references/herdr-gotchas.md
@@ -7,10 +7,11 @@ herdr の skill 文書（`herdr --skill` / 同梱の skill 定義）に書かれ
 「この tab の新しい pane」ではなく、**新しい workspace**（独立した tab 群）を作る。pane/tab ID ではなく workspace ID が新規発行される。
 
 ```bash
-herdr worktree create --workspace <ID> --branch <name> --base main --label "<label>" --no-focus
+herdr worktree create --workspace <ID> --branch <name> --base main --path .claude/worktree/<worktree-name> --label "<label>" --no-focus
 ```
 
 - `--workspace <ID>` と `--cwd <PATH>` は排他。両方渡すと `Exit code 2` になる。
+- `--path` は必ず指定する。省略すると herdr のデフォルト位置に作られ、Claude Code 自身が worktree を作るときのディレクトリ規則（リポジトリ直下の `.claude/worktree/<worktree-name>`）とズレる。
 - 戻り値の JSON に `result.root_pane.pane_id` と `result.workspace.workspace_id` が入っている。以降の `herdr pane` / `herdr agent` 呼び出しには `pane_id` を使う。
 - ユーザーが「今の tab に pane を追加して」のように指示していた場合、実際の挙動（workspace 単位の分離）と食い違う。一度確認を取ってから進めるのが安全（AskUserQuestion で選択肢を示すとよい）。手動で「同じ tab 内の pane」にしたい場合は、`git worktree add` を自分で実行してから `herdr pane split --direction right|down` で pane を追加する代替手順がある。
 


### PR DESCRIPTION
## Summary
- `herdr worktree create` に `--path .claude/worktree/<worktree-name>` を必須指定し、Claude Code 自身が worktree を作る際と同じディレクトリ規則に揃える
- SKILL.md と references/herdr-gotchas.md のコマンド例・注意書きを更新

## Test plan
- [ ] `herdr worktree create --help` で `--path` オプションの実在を確認済み
- [ ] 次回 genba-kantoku ワークフロー実行時に worktree が `.claude/worktree/<name>` 配下へ作成されることを確認