### PR TITLE
fix(herdr): resolve focused pane id for split command

### DIFF
--- a/.config/herdr/scripts/herdr-claude-pane.sh
+++ b/.config/herdr/scripts/herdr-claude-pane.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 # 新しいペインをワークスペース幅の 26% にする。--ratio は分割元の pane が保持する
 # 割合なので、タブ全体の幅と分割元の幅から毎回逆算する。分割元がワークスペース幅の
 # 半分より狭い場合は 26% を確保できないため、等分に倒す。
-ratio="$(herdr pane layout --current | jq -r '
+layout="$(herdr pane layout)"
+focused_pane="$(echo "$layout" | jq -r '.result.layout.focused_pane_id')"
+
+ratio="$(echo "$layout" | jq -r '
   .result.layout as $l
   | ($l.area.width * 0.26) as $target
   | ([$l.panes[] | select(.focused) | .rect.width][0]) as $src
@@ -12,7 +15,7 @@ ratio="$(herdr pane layout --current | jq -r '
   | if . < 0.5 then 0.5 else . end
 ')"
 
-new_pane="$(herdr pane split --current --direction right --ratio "$ratio" --focus \
+new_pane="$(herdr pane split "$focused_pane" --direction right --ratio "$ratio" --focus \
   | jq -r '.result.pane.pane_id')"
 
 herdr agent start claude --kind claude --pane "$new_pane"


### PR DESCRIPTION
## Summary
- `herdr pane layout --current` / `herdr pane split --current` の `--current` フラグ廃止に追従し、`herdr pane layout` の結果から `focused_pane_id` を取得して明示的に渡すよう修正

## Test plan
- [ ] `prefix+a` で `herdr-claude-pane.sh` を実行し、カレントペイン右にワークスペース幅 26% で Claude Code が開くことを確認